### PR TITLE
Fixed the wrong reference to layouts for es-label & es-select components

### DIFF
--- a/addon/components/es-form/es-label.js
+++ b/addon/components/es-form/es-label.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import layout from '../templates/components/es-form\es-label';
+import layout from '../../templates/components/es-form/es-label';
 
 export default Component.extend({
   layout

--- a/addon/components/es-form/es-select.js
+++ b/addon/components/es-form/es-select.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import layout from '../templates/components/es-form\es-select';
+import layout from '../../templates/components/es-form/es-select';
 
 export default Component.extend({
   layout

--- a/app/components/es-form/es-label.js
+++ b/app/components/es-form/es-label.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-styleguide/components/es-form\es-label';
+export { default } from 'ember-styleguide/components/es-form/es-label';

--- a/app/components/es-form/es-select.js
+++ b/app/components/es-form/es-select.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-styleguide/components/es-form\es-select';
+export { default } from 'ember-styleguide/components/es-form/es-select';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,6 +3164,13 @@ ember-maybe-in-element@^0.1.3:
   dependencies:
     ember-cli-babel "^6.11.0"
 
+ember-native-dom-helpers@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz#9c7172e4ddfa5dd86830c46a936e2f8eca3e5896"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.6.0"
+
 ember-popper@^0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.8.3.tgz#547ec0e8d810805bd65bce7556f0a3377cb9730c"


### PR DESCRIPTION
I saw when I first forked the project, failing test-cases. So fixed them and there is one more integration test which is failing `{{es-navbar}}`.