### PR TITLE
add ability to pass search component in via yield

### DIFF
--- a/addon/components/es-navbar/template.hbs
+++ b/addon/components/es-navbar/template.hbs
@@ -37,23 +37,27 @@
         {{/each}}
       {{/navbar.nav}}
       {{#navbar.nav as |nav|}}
-        <form class="navbar-form navbar-right searchbox">
-          <div class="input-group">
-            <label for="search-input" class="control-label sr-only">Search</label>
-            <input type="text"
-                   class="form-control search input ds-input"
-                   placeholder="Search..."
-                   id="search-input"
-                   role="combobox"
-                   aria-expanded="false"
-                   aria-owns="algolia-autocomplete-listbox-0"
-                   autocorrect="off"
-                   autocapitalize="none"
-                   spellcheck="false"
-            />
-            <span></span>
-          </div>
-        </form>
+        {{#if hasBlock}}
+          {{yield}}
+        {{else}}
+          <form class="navbar-form navbar-right searchbox">
+            <div class="input-group">
+              <label for="search-input" class="control-label sr-only">Search</label>
+              <input type="text"
+                     class="form-control search input ds-input"
+                     placeholder="Search..."
+                     id="search-input"
+                     role="combobox"
+                     aria-expanded="false"
+                     aria-owns="algolia-autocomplete-listbox-0"
+                     autocorrect="off"
+                     autocapitalize="none"
+                     spellcheck="false"
+              />
+              <span></span>
+            </div>
+          </form>
+        {{/if}}
       {{/navbar.nav}}
     {{/navbar.content}}
   {{/bs-navbar}}


### PR DESCRIPTION
this allows us to pass in the search component using https://github.com/ember-learn/ember-learn-search-components 

Example of this in use for the Guides-App: https://github.com/ember-learn/guides-app/pull/50/files#diff-f63965ba48df687541db46e0e1b2c2ecR10