### PR TITLE
add ability to pass search component into navbar via yield

### DIFF
--- a/addon/components/es-navbar/template.hbs
+++ b/addon/components/es-navbar/template.hbs
@@ -37,23 +37,27 @@
         {{/each}}
       {{/navbar.nav}}
       {{#navbar.nav as |nav|}}
-        <form class="navbar-form navbar-right searchbox">
-          <div class="input-group">
-            <label for="search-input" class="control-label sr-only">Search</label>
-            <input type="text"
-                   class="form-control search input ds-input"
-                   placeholder="Search..."
-                   id="search-input"
-                   role="combobox"
-                   aria-expanded="false"
-                   aria-owns="algolia-autocomplete-listbox-0"
-                   autocorrect="off"
-                   autocapitalize="none"
-                   spellcheck="false"
-            />
-            <span></span>
-          </div>
-        </form>
+        {{#if hasBlock}}
+          {{yield}}
+        {{else}}
+          <form class="navbar-form navbar-right searchbox">
+            <div class="input-group">
+              <label for="search-input" class="control-label sr-only">Search</label>
+              <input type="text"
+                     class="form-control search input ds-input"
+                     placeholder="Search..."
+                     id="search-input"
+                     role="combobox"
+                     aria-expanded="false"
+                     aria-owns="algolia-autocomplete-listbox-0"
+                     autocorrect="off"
+                     autocapitalize="none"
+                     spellcheck="false"
+              />
+              <span></span>
+            </div>
+          </form>
+        {{/if}}
       {{/navbar.nav}}
     {{/navbar.content}}
   {{/bs-navbar}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -902,7 +902,7 @@
     "async-promise-queue": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
-      "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
+      "integrity": "sha1-MIuq+8dK/2agu25/ShjU/oQ0RAw=",
       "requires": {
         "async": "2.5.0",
         "debug": "2.6.9"
@@ -15939,6 +15939,12 @@
         }
       }
     },
+    "ember-cli-import-polyfill": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz",
+      "integrity": "sha1-waCKiv+0XJe2dZJicv54z0yhZvI=",
+      "dev": true
+    },
     "ember-cli-inject-live-reload": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.7.0.tgz",
@@ -16786,6 +16792,33 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
+      }
+    },
+    "ember-cli-moment-shim": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-moment-shim/-/ember-cli-moment-shim-3.6.0.tgz",
+      "integrity": "sha512-Xb9HRnpH4x9I9un8zpf1rlSzSRpxDvcauA81pisgIfhrIWXsTq5VbCpHWI4ojFKgYTee03+5DtUaWcVT2uT/+g==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "2.0.1",
+        "broccoli-merge-trees": "2.0.0",
+        "broccoli-source": "1.1.0",
+        "broccoli-stew": "1.5.0",
+        "chalk": "1.1.3",
+        "ember-cli-babel": "6.11.0",
+        "ember-cli-import-polyfill": "0.2.0",
+        "exists-sync": "0.0.4",
+        "lodash.defaults": "4.2.0",
+        "moment": "2.21.0",
+        "moment-timezone": "0.5.14"
+      },
+      "dependencies": {
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+          "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
           "dev": true
         }
       }
@@ -20399,6 +20432,27 @@
         "ember-cli-babel": "6.11.0"
       }
     },
+    "ember-factory-for-polyfill": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
+      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-version-checker": "2.1.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.5.0"
+          }
+        }
+      }
+    },
     "ember-font-awesome": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/ember-font-awesome/-/ember-font-awesome-3.0.5.tgz",
@@ -21561,6 +21615,28 @@
         }
       }
     },
+    "ember-getowner-polyfill": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
+      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
+      "dev": true,
+      "requires": {
+        "ember-cli-version-checker": "2.1.0",
+        "ember-factory-for-polyfill": "1.3.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.5.0"
+          }
+        }
+      }
+    },
     "ember-in-element-polyfill": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ember-in-element-polyfill/-/ember-in-element-polyfill-0.1.2.tgz",
@@ -22402,6 +22478,17 @@
       "integrity": "sha512-cAiG6N9HwvoPsMIePgwECilPrKRrIdfKqx9g8qWHKPS4vwrgS2PTeLmOcJvVYbBTXkHaFZmecDRpf6xAj6zk7A==",
       "requires": {
         "ember-cli-babel": "6.11.0"
+      }
+    },
+    "ember-moment": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.6.0.tgz",
+      "integrity": "sha1-+CvrqBprn06juwrCRjzF0sXL2OY=",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "6.11.0",
+        "ember-getowner-polyfill": "2.2.0",
+        "ember-macro-helpers": "0.17.0"
       }
     },
     "ember-native-dom-helpers": {
@@ -23592,7 +23679,7 @@
     "ember-rfc176-data": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz",
-      "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg=="
+      "integrity": "sha1-alpLi4LsOvNPMBCWX6lrk2ypRRk="
     },
     "ember-runtime-enumerable-includes-polyfill": {
       "version": "2.1.0",
@@ -28546,6 +28633,21 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+    },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
+      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "dev": true,
+      "requires": {
+        "moment": "2.21.0"
+      }
     },
     "moo-server": {
       "version": "1.3.0",

--- a/tests/integration/components/es-navbar/component-test.js
+++ b/tests/integration/components/es-navbar/component-test.js
@@ -20,5 +20,5 @@ test('it renders', function(assert) {
     {{/es-navbar}}
   `);
 
-  assert.equal(this.$().text().trim(), 'Search');
+  assert.equal(this.$().text().trim(), 'template block text');
 });


### PR DESCRIPTION
this allows us to pass in the search component using https://github.com/ember-learn/ember-learn-search-components 

Example of this in use for the Guides-App: https://github.com/ember-learn/guides-app/pull/50/files#diff-f63965ba48df687541db46e0e1b2c2ecR10

(I manually rebased this to make sure that it would work with the big merge that happened recently)