### PR TITLE
Remove google plus link

### DIFF
--- a/addon/templates/components/es-footer.hbs
+++ b/addon/templates/components/es-footer.hbs
@@ -82,38 +82,6 @@
             </g>
           </svg>
         </a>
-        <a href="https://plus.google.com/communities/106387049790387471205" title="Google+">
-          <svg
-            xmlns:dc="http://purl.org/dc/elements/1.1/"
-            xmlns:cc="http://creativecommons.org/ns#"
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            xmlns:svg="http://www.w3.org/2000/svg"
-            xmlns="http://www.w3.org/2000/svg"
-            version="1.1"
-            id="svg4169"
-            viewBox="0 0 1500 1000">
-            <defs
-              id="defs4171" />
-            <metadata
-              id="metadata4174">
-              <rdf:RDF>
-                <cc:Work
-                  rdf:about="">
-                  <dc:format>image/svg+xml</dc:format>
-                  <dc:type
-                    rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-                  <dc:title></dc:title>
-                </cc:Work>
-              </rdf:RDF>
-            </metadata>
-            <g
-              id="layer1">
-              <path
-                id="path4717"
-                d="m 909,508.99057 q 0,117 -49,207 -49,90 -138,142 -89,52 -206,51 -83,0 -159,-32 -76,-32 -131,-87 -55,-55 -87,-131 -32,-76 -32,-159 0,-83 32,-159 32,-76 87,-131 55,-55 131,-87 76,-32.000003 159,-32.000003 160,0 274,107.000003 l -111,107 q -65,-63 -163,-63 -69,0 -127,34 -58,34 -92,94 -34,60 -34,130 0,70 34,130 34,60 92,94 58,34 127,34 46,0 85,-13 39,-13 64,-32 25,-19 44,-43 19,-24 27,-47 8,-23 12,-41 l -232,0 0,-141 386,0 q 7,36 7,68 z m 484,-68 0,118 -117,0 0,116 -117,0 0,-116 -117,0 0,-118 117,0 0,-116 117,0 0,116 117,0 z" />
-            </g>
-          </svg>
-        </a>
       </div>
     </div>
 

--- a/tests/integration/components/es-footer-test.js
+++ b/tests/integration/components/es-footer-test.js
@@ -14,7 +14,7 @@ test('it renders', function(assert) {
   const footerStyle = window.getComputedStyle(footer, null);
   const footerBgColor = footerStyle.getPropertyValue('background-color');
 
-  assert.equal(footerSocialLinks.length, 3, 'social links are loading');
+  assert.equal(footerSocialLinks.length, 2, 'social links are loading');
   assert.equal(footerContribtuionsLinks.length, 2, 'contributors links are loading');
   assert.equal(footerBgColor, 'rgb(242, 236, 233)', 'background color is rendering');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,6 +138,10 @@ acorn@^5.2.1, acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
 after@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.1.tgz#ab5d4fb883f596816d3515f8f791c0af486dd627"
@@ -3524,11 +3528,61 @@ eslint@^4.0.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
+eslint@^4.18.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
 espree@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
   dependencies:
     acorn "^5.4.0"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
 esprima-fb@~15001.1001.0-dev-harmony-fb:
@@ -7014,6 +7068,10 @@ regex-not@^1.0.0:
   dependencies:
     extend-shallow "^2.0.1"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -8089,7 +8147,7 @@ synesthesia@^1.0.1:
   dependencies:
     css-color-names "0.0.3"
 
-table@^4.0.1:
+table@4.0.2, table@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:


### PR DESCRIPTION
This PR removes the Google plus link from the footer. That page isn't active and has a bit of spam.

Note: The lock file changed on fresh install, but I think that's ok with yarn.