### PR TITLE
Configure automatically the `ember-cli-bootstrap` addon

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,11 +4,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    'ember-bootstrap': {
-      bootstrapVersion: 4,
-      importBootstrapFont: false,
-      importBootstrapCSS: false
-    },
     svgJar: {
       sourceDirs: [
         'public',

--- a/index.js
+++ b/index.js
@@ -18,11 +18,21 @@ module.exports = {
       ]
     },
     googleFonts: [
-      'Roboto:400,700' 
+      'Roboto:400,700'
     ],
   },
 
-  included() {
+  included(app, parentAddon) {
+    let target = (app || parentAddon);
+    target.options = target.options || {};
+
+    const defaultEmberBootStrapOptions = {
+      bootstrapVersion: 4,
+      importBootstrapFont: false,
+      importBootstrapCSS: false
+    };
+    target.options['ember-bootstrap'] = target.options['ember-bootstrap'] || defaultEmberBootStrapOptions;
+
     this._super.included.apply(this, arguments);
   },
 


### PR DESCRIPTION
This change removes the app requirement to configure the `ember-cli-bootstrap` addon to make `ember-styleguide` works.

This change is part of the ongoing work to use the addon on ember-learn/ember-help-wanted#17

If this is merged, the `ember-cli-bootstrap` configuration at the [guides-app](https://github.com/ember-learn/guides-app/blob/master/ember-cli-build.js#L26) could be removed.

Could someone enumerate the projects using `ember-styleguide`?




