### PR TITLE
fixing sass error in consuming applications

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const mergeTrees = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const path = require('path');
+const nodeSass = require('node-sass');
 
 module.exports = {
   name: require('./package').name,
@@ -31,7 +32,10 @@ module.exports = {
       importBootstrapFont: false,
       importBootstrapCSS: false
     };
+
     target.options['ember-bootstrap'] = target.options['ember-bootstrap'] || defaultEmberBootStrapOptions;
+
+    target.options.sassOptions = target.options.sassOptions || { implementation: nodeSass };
 
     this.checkPreprocessor();
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-sass": "^8.0.1",
     "ember-svg-jar": "^1.2.2",
-    "ember-truth-helpers": "^2.1.0"
+    "ember-truth-helpers": "^2.1.0",
+    "node-sass": "^4.9.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -76,7 +77,6 @@
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-node": "^7.0.1",
     "loader.js": "^4.7.0",
-    "node-sass": "^4.9.4",
     "normalize.css": "^8.0.0",
     "np": "*",
     "qunit-dom": "^0.8.0",


### PR DESCRIPTION
As a result of the upgrade to ember-cli-sass and the fact that it is a **dependency** of ember-styleguide all consuming apps would need to update their config to get this to work again, which would mean a major version bump of this addon.

This PR fixes that 👍 and prevents errors like the following: 

```
6:31:34 PM: Could not find the default SASS implementation. Run the default blueprint:
6:31:34 PM:    ember g ember-cli-sass
6:31:34 PM: Or install an implementation such as "node-sass" and add an implementation option. For example:
6:31:34 PM:    sassOptions: {implementation: require("node-sass")}
```