### PR TITLE
Set isDevelopingAddon to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const nodeSass = require('node-sass');
 
 module.exports = {
   name: require('./package').name,
-  isDevelopingAddon() {
-    return true;
-  },
+  // isDevelopingAddon() {
+  //   return true;
+  // },
 
   options: {
     svgJar: {


### PR DESCRIPTION
Publishing the addon with isDevelopingAddon to true causes undesirable things such as an app's linting evaluating styleguide addon files (which is happening with ember-api-docs right now).