### PR TITLE
prevent crash when addon depends on ember-styleguide

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = {
   },
 
   checkPreprocessor() {
-    if (!this.app.project.findAddonByName('ember-cli-sass')) {
+    if (this.app && !this.app.project.findAddonByName('ember-cli-sass')) {
       this.ui.writeLine('ember-styleguide: npm package "ember-cli-sass" is missing. Consider using it to use `@import \'ember-styleguide/globals/variables\'` in your styles.');
     }
   }


### PR DESCRIPTION
This check for ember-cli-sass is causing a crash in the build when an **addon** depends on ember-styleguide (as opposed to an app directly)

This change doesn't change any functionality as it's wrapping a console log 👍 