### PR TITLE
Implementing default links for the navbar

### DIFF
--- a/addon/components/es-navbar/component.js
+++ b/addon/components/es-navbar/component.js
@@ -1,6 +1,16 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+
 import layout from './template';
+import defaultLinks from '../../constants/links';
 
 export default Component.extend({
-  layout
+  layout,
+  navLinks: computed('links.[]', function() {
+    if(this.links) {
+      return this.links;
+    }
+
+    return defaultLinks;
+  })
 });

--- a/addon/components/es-navbar/template.hbs
+++ b/addon/components/es-navbar/template.hbs
@@ -10,7 +10,7 @@
     {{navbar.toggle}}
     {{#navbar.content}}
       {{#navbar.nav class="mr-auto" as |nav|}}
-        {{#each links as |link|}}
+        {{#each navLinks as |link|}}
           {{#if (eq link.type "link")}}
             {{#nav.item}}
               <a href={{link.href}} class="nav-link">{{link.name}}</a>

--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -93,7 +93,7 @@ export default [{
     type: 'divider'
   }, {
     href: 'https://emberjs.com/logos',
-    name: 'Brand',
+    name: 'Logos',
     type: 'link'
   }, {
     href: 'https://emberjs.com/mascots',
@@ -120,5 +120,4 @@ export default [{
     name: 'Security',
     type: 'link'
   }]
-}]
-
+}];

--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -93,7 +93,7 @@ export default [{
     type: 'divider'
   }, {
     href: 'https://emberjs.com/logos',
-    name: 'Logos',
+    name: 'Branding',
     type: 'link'
   }, {
     href: 'https://emberjs.com/mascots',

--- a/tests/dummy/app/controllers/docs/components/es-navbar.js
+++ b/tests/dummy/app/controllers/docs/components/es-navbar.js
@@ -1,10 +1,34 @@
 import Controller from '@ember/controller';
-import navbarLinks from 'dummy/data/navbar-links';
+
+let customLinks = [{
+  name: 'Documentation',
+  type: 'dropdown',
+  items: [{
+    href: 'https://guides.emberjs.com',
+    name: 'The Marvelous Ember Guides!',
+    type: 'link'
+  }]
+}, {
+  name: 'Main Sites',
+  type: 'dropdown',
+  items: [{
+    href: 'https://emberjs.com',
+    name: 'Homepage',
+    type: 'link'
+  }, {
+    href: 'https://emberjs.com/api',
+    name: 'API Documentation',
+    type: 'link'
+  }, {
+    href: 'https://emberjs.com/builds',
+    name: 'Builds',
+    type: 'link'
+  }]
+}];
 
 export default Controller.extend({
   init() {
     this._super(...arguments);
-    this.set('links', navbarLinks);
+    this.set('customLinks', customLinks);
   }
 });
-

--- a/tests/dummy/app/templates/docs/components/es-navbar.md
+++ b/tests/dummy/app/templates/docs/components/es-navbar.md
@@ -1,12 +1,19 @@
 # Navbar
 
-Use a json file to identify what links you want in your navbar. 
+The navbar comes with the default Ember links, if you would like to override the default links you can pass a json object to update the links in the navbar.
 
 {{#docs-demo as |demo|}}
-  {{#demo.example name='es-navbar.hbs'}}
-    {{es-navbar/component links=links}}
+  {{#demo.example name='es-navbar-default.hbs'}}
+    {{es-navbar}}
   {{/demo.example}}
-  {{demo.snippet 'es-navbar.hbs'}}
+  {{demo.snippet 'es-navbar-default.hbs'}}
+{{/docs-demo}}
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='es-navbar-custom.hbs'}}
+    {{es-navbar links=customLinks}}
+  {{/demo.example}}
+  {{demo.snippet 'es-navbar-custom.hbs'}}
 {{/docs-demo}}
 
 <aside role="note">


### PR DESCRIPTION
This is a backwards compatible change that allows for default links to be provided by the ember-styleguide. 

This prevents every consuming app from needing to define the links but allows them to define them if the need/want to. It also exposes the default links for import so consuming apps can make small changes to the links object instead of it being "all or nothing" 👍 