### PR TITLE
Add CLI Guides to the default navbar links

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -3,11 +3,15 @@ export default [{
   type: 'dropdown',
   items: [{
     href: 'https://guides.emberjs.com',
-    name: 'Guides',
+    name: 'Ember.js Guides',
     type: 'link'
   }, {
     href: 'https://emberjs.com/api',
     name: 'API Reference',
+    type: 'link'
+  }, {
+    href: 'https://cli.emberjs.com',
+    name: 'CLI Guides',
     type: 'link'
   }, {
     type: 'divider'


### PR DESCRIPTION
I have added the CLI guides to the "Docs" dropdown, and clarified "The Guides" as "Ember.js Guides".

I did not add a link to the CLI Guides API because I think it's ok for someone to get to it via the Guides. The CLI API docs also need some kind of review before they are included in the top navbar.

"The Guides" are really "The Ember.js Guides" because as we make more guides (like Ember Data, Ember CLI, etc) we need more granular descriptions.

These 3 PRs should be merged at the same time:
1. ember-styleguide https://github.com/ember-learn/ember-styleguide/pull/115
2. ember-api-docs https://github.com/ember-learn/ember-api-docs/pull/576
3. website https://github.com/emberjs/website/pull/3705