### PR TITLE
[#123] / Convert es-footer to be an angle bracket component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
 jobs:
   fail_fast: true
   allow_failures:
+      env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
+      env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ env:
 jobs:
   fail_fast: true
   allow_failures:
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:
@@ -39,8 +37,6 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/addon/templates/components/es-footer.hbs
+++ b/addon/templates/components/es-footer.hbs
@@ -13,7 +13,7 @@
 
       {{!--
         Pass footer properties to support
-        {{es-footer tagline="My custom tagline" contributorLinks=myLinks}}
+        <EsFooter @tagline={{"My custom tagline" contributorLinks=myLinks}}/>
       --}}
       {{es-footer/es-info infoLinks=infoLinks}}
       {{es-footer/es-statement tagline=tagline socialLinks=socialLinks}}

--- a/addon/templates/components/es-footer.hbs
+++ b/addon/templates/components/es-footer.hbs
@@ -13,7 +13,7 @@
 
       {{!--
         Pass footer properties to support
-        <EsFooter @tagline={{"My custom tagline" contributorLinks=myLinks}}/>
+        <EsFooter @tagline="My custom tagline" @contributorLinks={{myLinks}}/>
       --}}
       {{es-footer/es-info infoLinks=infoLinks}}
       {{es-footer/es-statement tagline=tagline socialLinks=socialLinks}}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-cli-deploy-git": "^1.3.3",
     "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-eslint": "^4.2.3",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.5",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-mirage": "^0.4.9",
     "ember-cli-moment-shim": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-cli-deploy-git": "^1.3.3",
     "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-eslint": "^4.2.3",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.5",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-mirage": "^0.4.9",
     "ember-cli-moment-shim": "^3.5.0",

--- a/tests/dummy/app/templates/docs/components/es-footer.md
+++ b/tests/dummy/app/templates/docs/components/es-footer.md
@@ -2,14 +2,14 @@
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='demo1'}}
-    {{es-footer }}
+    <EsFooter/>
   {{/demo.example}}
   {{demo.snippet 'demo1'}}
 {{/docs-demo}}
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='demo2'}}
-    {{es-footer tagline="A framework for ambitious web developers"}}
+    <EsFooter @tagline="A framework for ambitious web developers"/>
   {{/demo.example}}
   {{demo.snippet 'demo2'}}
 {{/docs-demo}}
@@ -18,11 +18,11 @@
   {{#demo.example name='demo3'}}
     {{!-- Check out the component blocks and their respective
     configuration --}}
-    {{#es-footer as |f|}}
-      {{f.info infoLinks=infoLinks}}
-      {{f.statement socialLinks=socialLinks}}
-      {{f.contributions contributorLinks=contributorLinks}}
-    {{/es-footer}}
+    <EsFooter as |f|>
+      <f.info @infoLinks={{infoLinks}}/>
+      <f.statement @socialLinks={{socialLinks}}/>
+      <f.contributions @contributorLinks={{contributorLinks}}/>
+    </EsFooter>
   {{/demo.example}}
   {{demo.snippet 'demo3'}}
 {{/docs-demo}}
@@ -30,25 +30,25 @@
 {{#docs-demo as |demo|}}
   {{#demo.example name='demo4'}}
     {{!-- You can also add your own content on each component block --}}
-    {{#es-footer as |f|}}
-      {{#f.info}}
+    <EsFooter as |f|>
+      <f.info>
         <br/>
         <a>Team</a>
         <br/>
         <a>Contact</a>
-      {{/f.info}}
-      {{#f.statement}}
+      </f.info>
+      <f.statement>
         Highly Productive Out of the Box
-      {{/f.statement}}
-      {{#f.contributions}}
+      </f.statement>
+      <f.contributions>
         <div class="contributor">
           <p>Hosted by:</p>
           <a href="https://www.heroku.com/emberjs">
             {{svg-jar "heroku-logo" class="contributor-logo"}}
           </a>
         </div>
-      {{/f.contributions}}
-    {{/es-footer}}
+      </f.contributions>
+    </EsFooter>
   {{/demo.example}}
   {{demo.snippet 'demo4'}}
 {{/docs-demo}}

--- a/tests/dummy/app/templates/docs/components/es-footer.md
+++ b/tests/dummy/app/templates/docs/components/es-footer.md
@@ -19,9 +19,9 @@
     {{!-- Check out the component blocks and their respective
     configuration --}}
     <EsFooter as |f|>
-      <f.info @infoLinks={{infoLinks}}/>
-      <f.statement @socialLinks={{socialLinks}}/>
-      <f.contributions @contributorLinks={{contributorLinks}}/>
+      <f.info @infoLinks={{infoLinks}} />
+      <f.statement @socialLinks={{socialLinks}} />
+      <f.contributions @contributorLinks={{contributorLinks}} />
     </EsFooter>
   {{/demo.example}}
   {{demo.snippet 'demo3'}}

--- a/tests/integration/components/es-footer-test.js
+++ b/tests/integration/components/es-footer-test.js
@@ -7,7 +7,7 @@ module('Integration | Component | es footer', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`{{es-footer}}`);
+    await render(hbs`<EsFooter/>`);
 
     const footerSocialLinks = document.querySelectorAll('.footer-social a');
     const footerContribtuionsLinks = document.querySelectorAll('.footer-contributions .contributor');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,16 +5192,7 @@ ember-compatibility-helpers@^1.0.0, ember-compatibility-helpers@^1.0.0-beta.2:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-compatibility-helpers@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
-  integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
-  dependencies:
-    babel-plugin-debug-macros "^0.2.0"
-    ember-cli-version-checker "^2.1.1"
-    semver "^5.4.1"
-
-ember-compatibility-helpers@^1.1.1:
+ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
   integrity sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,7 +4778,7 @@ ember-cli-htmlbars-inline-precompile@^1.0.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars-inline-precompile@^1.0.3:
+ember-cli-htmlbars-inline-precompile@^1.0.3, ember-cli-htmlbars-inline-precompile@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.5.tgz#312e050c9e3dd301c55fb399fd706296cd0b1d6a"
   integrity sha512-/CNEqPxroIcbY6qejrt704ZaghHLCntZKYLizFfJ2esirXoJx6fuYKBY1YyJ8GOgjfbHHKjBZuK4vFFJpkGqkQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,7 +4778,7 @@ ember-cli-htmlbars-inline-precompile@^1.0.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars-inline-precompile@^1.0.3, ember-cli-htmlbars-inline-precompile@^1.0.5:
+ember-cli-htmlbars-inline-precompile@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.5.tgz#312e050c9e3dd301c55fb399fd706296cd0b1d6a"
   integrity sha512-/CNEqPxroIcbY6qejrt704ZaghHLCntZKYLizFfJ2esirXoJx6fuYKBY1YyJ8GOgjfbHHKjBZuK4vFFJpkGqkQ==
@@ -5192,7 +5192,16 @@ ember-compatibility-helpers@^1.0.0, ember-compatibility-helpers@^1.0.0-beta.2:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1:
+ember-compatibility-helpers@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
+  integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
+ember-compatibility-helpers@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
   integrity sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==


### PR DESCRIPTION
This PR converts `{{es-footer}}` component to `<EsFooter/>`. #123 

**Note**: This PR also adds [ember-angle-bracket-invocation-polyfill](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill), so we can continue supporting `2.16` and `2.18` versions.


![screen recording 2018-12-02 at 12 17 pm](https://user-images.githubusercontent.com/1156865/49342686-4f0c4c00-f62c-11e8-8786-e0ad69546c34.gif)
