### PR TITLE
Navbar text update - Clarify that API docs are for Ember

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -7,11 +7,11 @@ export default [{
     type: 'link'
   }, {
     href: 'https://emberjs.com/api',
-    name: 'API Reference',
+    name: 'Ember.js API Reference',
     type: 'link'
   }, {
     href: 'https://cli.emberjs.com',
-    name: 'CLI Guides',
+    name: 'CLI Guides and API',
     type: 'link'
   }, {
     type: 'divider'


### PR DESCRIPTION
As noted in https://github.com/ember-learn/cli-guides/issues/65, "API Reference" is ambiguous. API for what? This changes it to "Ember.js API Reference," and "CLI Guides and API."

Thoughts?