### PR TITLE
Fixing issue with element not being available when setting tabIndex

### DIFF
--- a/addon/components/es-navbar/link/component.js
+++ b/addon/components/es-navbar/link/component.js
@@ -30,13 +30,9 @@ export default Component.extend({
 
   navbar: service(),
 
-  init() {
-    this._super(...arguments);
-
-    this.element.tabIndex = -1;
-  },
-
   didInsertElement() {
+    this.element.tabIndex = -1;
+
     this.get('navbar').register(this);
     this.domNode = this.element.querySelector('ul[role="menu"]');
 


### PR DESCRIPTION
This is something that is causing a few issues when starting an app as a result of merging #77 

I'm not entirely sure why this didn't show up in the tests for ember-styleguide 🤔 and I'm also not 100% sure why this isn't breaking Percy on the new website with this PR: https://github.com/ember-learn/ember-website/pull/135

Something strange is going on but this PR is required to fix the issues. We shouldn't be accessing the element before the element is added to the dom