### PR TITLE
replacing &rarr; with →

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -29,15 +29,15 @@ export default [{
     type: 'link'
   }, {
     href: 'https://emberjs.com/builds/release',
-    name: '&rarr; Stable',
+    name: '→ Stable',
     type: 'link'
   }, {
     href: 'https://emberjs.com/builds/beta',
-    name: '&rarr; Beta',
+    name: '→ Beta',
     type: 'link'
   }, {
     href: 'https://emberjs.com/builds/canary',
-    name: '&rarr; Canary',
+    name: '→ Canary',
     type: 'link'
   }, {
     type: 'divider'


### PR DESCRIPTION
This fixes an issue with the default links.

Before: 

![screenshot 2019-01-27 at 20 02 37](https://user-images.githubusercontent.com/594890/51806193-c9dd9600-226e-11e9-84a4-d3ad0e6b5a16.png)

After: 

![screenshot 2019-01-27 at 20 03 16](https://user-images.githubusercontent.com/594890/51806195-cf3ae080-226e-11e9-94f5-571f3d118c32.png)
