### PR TITLE
Fixing default links

### DIFF
--- a/addon/components/es-navbar/template.hbs
+++ b/addon/components/es-navbar/template.hbs
@@ -7,7 +7,7 @@
   </a>
 
   <ul role="menubar" aria-expanded="false">
-    {{#each links as |link index|}}
+    {{#each navLinks as |link index|}}
       {{es-navbar/link link=link index=index}}
     {{/each}}
   </ul>


### PR DESCRIPTION
I think this was something that was lost in the navbar update. This fix is needed for the default links to still be in effect 👍 