### PR TITLE
es-navbar: hide menu items when navbar is closed

### DIFF
--- a/addon/styles/_es-navbar.scss
+++ b/addon/styles/_es-navbar.scss
@@ -143,6 +143,12 @@ ul[role="menubar"] ul[role="menu"] a[aria-haspopup="true"]:after {
   background-size: 100% 100%;
 }
 
+@media (max-width: 991px) {
+  ul[role="menubar"][aria-expanded="false"] > li {
+    display: none;
+  }
+}
+
 // Large devices (desktops, 992px and up)
 @media (min-width: 992px) {
   nav.es-navbar div.container {


### PR DESCRIPTION
This is a simple fix that prevents a small bug in the new navbar. It is best illustrated in a screenshot: 

Before: 

![screenshot 2019-01-31 at 22 01 50](https://user-images.githubusercontent.com/594890/52088512-fc0b3280-25a3-11e9-93f6-397a293b51f8.png)


After: 

![screenshot 2019-01-31 at 22 02 15](https://user-images.githubusercontent.com/594890/52088520-01687d00-25a4-11e9-93df-39abe20d61a4.png)
