### PR TITLE
Add closePopupMenu function to navbar service

### DIFF
--- a/addon/services/navbar.js
+++ b/addon/services/navbar.js
@@ -13,6 +13,10 @@ export default Service.extend({
     this.firstChars.push(item.element.querySelector('a').text.trim()[0].toLowerCase());
   },
 
+  closePopupMenu() {
+    this.items.forEach(item => item.closePopupMenu());
+  },
+
   setFocusToNextItem(item) {
     const items = this.get('items');
 


### PR DESCRIPTION
As discussed with @mansona offline this is required for fixing https://github.com/ember-learn/ember-website/issues/151

The PR introduces a `closePopupMenu` method to the `navbar` service. This allows you to close the `es-navbar` dropdown if it's open.

```js
this.navbar.closePopupMenu();
```

I was trying to add a unit test for the new function but it wasn't straightforward. It's a bit janky as internally the `navbar#register` method accesses the DOM which isn't available in a unit test. Any thoughts?