### PR TITLE
Add lts to builds in the navbar

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -25,7 +25,11 @@ export default [{
   type: 'dropdown',
   items: [{
     href: 'https://emberjs.com/releases',
-    name: 'Channels',
+    name: 'Overview',
+    type: 'link'
+  }, {
+    href: 'https://emberjs.com/releases/lts',
+    name: '→ LTS',
     type: 'link'
   }, {
     href: 'https://emberjs.com/releases/release',


### PR DESCRIPTION
Sister PR with https://github.com/ember-learn/ember-website/pull/351
Should only be merged and released after that PR.

I changed the page name to "Overview" because "Channels" doesn't describe the content anymore.