### PR TITLE
deprecating es-ulist

### DIFF
--- a/addon/components/es-ulist.js
+++ b/addon/components/es-ulist.js
@@ -2,8 +2,17 @@ import Component from '@ember/component';
 import layout from '../templates/components/es-ulist';
 import { computed } from '@ember/object';
 
+import { deprecate } from '@ember/application/deprecations';
 
 export default Component.extend({
+  init() {
+    this._super(...arguments);
+
+    deprecate('es-ulist is deprecated and will be removed in the next version of ember-styleguide. If you think this has been done in error please contact the Learning Team in #dev-ember-learning in the Ember Community Discord.', null, {
+      id: 'styleguide-es-ulist',
+      until: '4.0.0'
+    });
+  },
   layout,
   classNames: ['es-ulist'],
   classNameBindings: ['hasBorder:bordered'],


### PR DESCRIPTION
Currently `{{es-ulist}}` is being used in **none** of the apps that depend on the ember-styleguide. This PR deprecates the use of es-ulist and allows us to remove it in the [website-redesign-rfc branch](https://github.com/ember-learn/ember-styleguide/pull/145)

Closes https://github.com/ember-learn/ember-styleguide/pull/130