### PR TITLE
Deprecate es pagewrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,4 @@ For more information on using ember-cli, visit [https://ember-cli.com/](https://
 * Each component must have the component name attached to the component as a CSS class.
 * It may feel as though there is duplicated code throughout these components; during the WIP process, we are favoring duplication over abstraction. 
 * Font icons through [ember-fontawesome](https://fontawesome.com/how-to-use/on-the-web/using-with/ember) - it is supported by the font awesome team and they render to SVG. 
-* The `es-pagewrapper` component has a property to indicate if there will be a sidebar or not. There might be a better way to do this.
 * In this addon, the `section` element is used as a container and is intended to span the full width of the viewport. 

--- a/addon/components/es-pagewrapper.js
+++ b/addon/components/es-pagewrapper.js
@@ -1,8 +1,20 @@
 import Component from '@ember/component';
 import layout from '../templates/components/es-pagewrapper';
 
+import { deprecate } from '@ember/application/deprecations';
+
 export default Component.extend({
   layout,
+
+  init() {
+    this._super(...arguments);
+
+    deprecate('es-pagewrapper is deprecated and will be removed in the next version of ember-styleguide. If you think this has been done in error please contact the Learning Team in #dev-ember-learning in the Ember Community Discord.', null, {
+      id: 'styleguide-es-ulist',
+      until: '4.0.0'
+    });
+  },
+
   classNameBindings: ['hasAside:pagewrapper-aside:pagewrapper'],
   hasAside: false,
   ariaRole: 'presentation',

--- a/tests/dummy/app/templates/docs/components/es-pagewrapper.md
+++ b/tests/dummy/app/templates/docs/components/es-pagewrapper.md
@@ -1,5 +1,7 @@
 # Page Wrapper
 
+**Note: this component is deprecated and will be removed in the next version of ember-styleguide**
+
 {{#docs-demo as |demo|}}
   {{#demo.example name='es-pagewrapper'}}
     {{es-pagewrapper}}

--- a/tests/dummy/app/templates/docs/components/es-ulist.md
+++ b/tests/dummy/app/templates/docs/components/es-ulist.md
@@ -2,6 +2,8 @@
 
 The list component is an unstyled, unordered list. A title must be defined, but can be visually hidden.
 
+**Note: this component is deprecated and will be removed in the next version of ember-styleguide**
+
 ## Uses
 
 ### Unstyled, Unordered List


### PR DESCRIPTION
This PR is similar to https://github.com/ember-learn/ember-styleguide/pull/200 

I just want to deprecate the use of `{{es-pagewrapper}}` so that I can remove it from the next version of the styleguide 👍 

Note: it is not used anywhere in an app consuming the styleguide