### PR TITLE
Removed alternate text for es-note component, which will show Zoey or Tomster image

### DIFF
--- a/addon/templates/components/es-note.hbs
+++ b/addon/templates/components/es-note.hbs
@@ -9,5 +9,5 @@
       {{/if}}
     </div>
   </div>
-  <img src={{imageUrl}} role="presentation" alt="Ember Mascot">
+  <img src={{imageUrl}} role="presentation" alt="">
 </div>


### PR DESCRIPTION
Now, all images with a presentation role have an empty `alt` text.
<img width="650" alt="after_changes_2" src="https://user-images.githubusercontent.com/16869656/65999228-9937a700-e462-11e9-87c4-47adf45dad4c.png">