### PR TITLE
Small navbar fixes

### DIFF
--- a/addon/components/es-navbar.js
+++ b/addon/components/es-navbar.js
@@ -20,7 +20,7 @@ export default class EsNavbar extends Component {
   }
 
   toggleMenu() {
-    let menu = document.querySelector('.navbar-list');
+    let menu = this.element.querySelector('.navbar-list');
     menu.setAttribute('aria-expanded', menu.getAttribute('aria-expanded') !== 'true');
   }
 }

--- a/addon/styles/components/es-navbar.css
+++ b/addon/styles/components/es-navbar.css
@@ -114,6 +114,7 @@
   li.separator {
     margin: 0;
     height: 0;
+    list-style: none;
     /* TODO fix this */
     border-bottom: 1px solid black;
   }


### PR DESCRIPTION
Fixing a slight list item anomaly in the nav bar: 

<img width="302" alt="Screenshot 2019-10-07 at 21 23 56" src="https://user-images.githubusercontent.com/594890/66346382-f7c0c180-e949-11e9-8136-f4de7a0e74d0.png">

(I'm not entirely sure why that isn't there in the styleguide 🤔 )

And reverting something that shouldn't have made it into my previous PR: https://github.com/ember-learn/ember-styleguide/pull/219#discussion_r331967751