### PR TITLE
fix background swipe-top

### DIFF
--- a/addon/styles/background-shapes.css
+++ b/addon/styles/background-shapes.css
@@ -21,7 +21,7 @@
 }
 
 .bg-shape-swipe-top {
-  background: url(/images/swipe-top.svg) no-repeat top center;
+  background: var(--color-orange) url('/images/swipe-top.svg') no-repeat bottom left;
   background-size: contain;
 }
 

--- a/docs/concepts/background-shapes.md
+++ b/docs/concepts/background-shapes.md
@@ -66,9 +66,6 @@ The other type of background shape is a "swipe" that can either be a swipe acros
   <div class="col-4-large offset-1-large text-center margin-vertical-large">
     <h2>More stuff to show location of swipe</h2>
   </div>
-  <div class="col-4-large offset-1-large text-center margin-vertical-large">
-    <h2>yes this needs quite a large section</h2>
-  </div>
 </div>
 ```
 

--- a/public/images/swipe-top.svg
+++ b/public/images/swipe-top.svg
@@ -1,1 +1,1 @@
-<svg width="1200" height="783" xmlns="http://www.w3.org/2000/svg"><path d="M0 .033L1200 0v433.087L0 783z" fill="#E04E38" fill-rule="nonzero"/></svg>
+<svg width="1200" height="350" xmlns="http://www.w3.org/2000/svg"><path fill="#FFF" fill-rule="nonzero" d="M1200 350V0L0 350z"/></svg>


### PR DESCRIPTION
This is a small change to the way swipe-top works, it is now pinned to the bottom left of the section that it is applied to.

This gives you more control over where the "swipe" actually goes and what it covers 👍 