### PR TITLE
Add presentation role to image in es-card if its alternate text is empty string

### DIFF
--- a/addon/templates/components/es-card.hbs
+++ b/addon/templates/components/es-card.hbs
@@ -1,6 +1,6 @@
 <li class="card" ...attributes>
   {{#if @image}}
-    <img class="card__image" src={{@image}} alt={{if @alt @alt ""}}>
+    <img class="card__image" src={{@image}} alt={{if @alt @alt ""}} role={{unless @alt "presentation"}}>
   {{/if}}
   <div class="card-content">
     {{yield}}


### PR DESCRIPTION
Currently, there's not a way to set the built-in `<img>` tag's `role` attribute for `<EsCard>` component. If we directly pass `role="presentation"` to the `<EsCard>` declaration, the role gets set on the `<li>` tag instead.