### PR TITLE
Sizes, layout and grids

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -4,7 +4,10 @@
 @import 'typography.css';
 @import 'colors.css';
 @import 'helpers.css';
+@import 'container.css';
 @import 'layout.css';
+@import 'grid.css';
+@import 'flex.css';
 @import 'icon.css';
 @import 'background-shapes.css';
 

--- a/addon/styles/background-shapes.css
+++ b/addon/styles/background-shapes.css
@@ -22,7 +22,9 @@
 
 .bg-shape-swipe-top {
   background: var(--color-brand) url('/images/swipe-top.svg') no-repeat bottom left;
-  background-size: contain;
+  background-size: cover;
+  /* this fixes a slight rendering issue in chrome */
+  margin-bottom: -1px;
 }
 
 .bg-shape-swipe-bottom {

--- a/addon/styles/components/es-footer.css
+++ b/addon/styles/components/es-footer.css
@@ -13,7 +13,7 @@
     padding: var(--spacing-2) 0;
 
     & .footer-logo {
-      height: 5rem;
+      height: 3rem;
     }
   }
 

--- a/addon/styles/components/es-header.css
+++ b/addon/styles/components/es-header.css
@@ -3,7 +3,7 @@
   justify-content: center;
   align-items: center;
   background-color: var(--color-gray-900);
-  padding: 1rem var(--grid-margin);
+  padding: 0 var(--grid-margin);
 }
 
 .es-header ul,
@@ -16,27 +16,29 @@
   color: var(--color-gray-100);
   display: flex;
   flex-direction: column;
-  font-size: 2rem;
+  font-size: inherit;
   max-width: var(--container-width);
   width: 100%;
+  padding: 0.5rem 0;
 }
 
 .navbar-brand-wrapper {
   display: block;
-  margin-right: auto;
-  border-radius: 10px;
+  height: 2.5rem;
+  margin: auto auto auto 0;
+  border-radius: var(--radius-lg);
 }
 
 .navbar-brand {
   display: block;
-  height: 5rem;
-  margin: 0 0 0 -0.5rem;
+  height: 100%;
+  width: auto;
 }
 
 .navbar-list {
-  margin: 1.5rem -1.5rem 0;
-  padding: 0;
   display: none;
+  margin: 0.5rem -0.5rem 0;
+  padding: 0;
   font-weight: var(--font-weight-3);
   list-style: none;
 }
@@ -44,29 +46,32 @@
 .navbar-list > li > * {
   display: block;
   text-align: left;
-  font-size: inherit;
+  font-size: var(--font-size-base);
   font-weight: inherit;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
+  box-sizing: border-box;
+  line-height: var(--line-height-base);
+  color: #fff;
 }
 
-[aria-expanded='true'] ~ .navbar-list,
-[aria-expanded='true'] ~ .navbar-end {
+[aria-expanded="true"] ~ .navbar-list,
+[aria-expanded="true"] ~ .navbar-end {
   display: block;
 }
 
 .navbar-toggler {
-  display: inline-block;
-  border: 0;
-  margin: -5rem -0.5rem 0 auto;
+  display: block;
+  width: 3rem;
+  height: 2rem;
+  margin: -2.25rem -0.5rem 0.25rem auto;
   padding: 0;
-  width: 4.5rem;
-  height: 5rem;
+  border: 0;
   background: transparent
     url("data:image/svg+xml,%3Csvg height='24' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M19 18a1 1 0 0 1 0 2H1a1 1 0 0 1 0-2zm0-7a1 1 0 0 1 0 2H1a1 1 0 0 1 0-2zm0-7a1 1 0 0 1 0 2H1a1 1 0 1 1 0-2z' fill='%23fff' fill-rule='evenodd'/%3E%3C/svg%3E")
-    right 1rem center no-repeat;
+    center no-repeat;
   overflow: hidden;
   text-indent: -999rem;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
 }
 
 .navbar-list-item {
@@ -74,29 +79,29 @@
 }
 
 .navbar-list-item-link,
-.navbar-list-item-dropdown-toggle {
-  margin: 0 0.5rem;
-  line-height: 3rem;
-  padding: 1rem;
-  color: #fff;
+.navbar-list-item-dropdown-toggle,
+.navbar-dropdown-list-item-link {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  box-sizing: border-box;
 }
 
 .navbar-list-item-link {
   display: block;
   color: inherit;
   text-decoration: none;
+  width: unset;
 }
 
 .navbar-list-item-dropdown-toggle {
-  width: calc(100% - 1rem);
   border: 0;
   display: block;
-  padding-right: 3rem;
+  padding-right: 2rem;
   text-decoration: none;
   white-space: nowrap;
   background: transparent
     url("data:image/svg+xml,%3Csvg width='8' height='8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M.295 3.707C-.335 3.077.11 2 1.002 2h5.996c.891 0 1.337 1.077.707 1.707l-2.998 3a1 1 0 0 1-1.414 0l-2.998-3z' fill='%23A3A6AF' fill-rule='nonzero'/%3E%3C/svg%3E")
-    right 2rem center no-repeat;
+    right 1.25rem center no-repeat;
 }
 
 .navbar-list-item-dropdown-toggle:focus,
@@ -104,26 +109,26 @@
   background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M.295 3.707C-.335 3.077.11 2 1.002 2h5.996c.891 0 1.337 1.077.707 1.707l-2.998 3a1 1 0 0 1-1.414 0l-2.998-3z' fill='%23FFF' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
-.navbar-list-item-dropdown-toggle[aria-expanded='true'] {
+.navbar-list-item-dropdown-toggle[aria-expanded="true"] {
   color: #ff5c44;
   background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M.295 4.293C-.335 4.923.11 6 1.002 6h5.996c.891 0 1.337-1.077.707-1.707l-2.998-3a1 1 0 0 0-1.414 0l-2.998 3z' fill='%23E04E39' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
 .navbar-dropdown-list {
-  margin: 0 1.5rem 1rem;
+  margin: 0;
   padding: 0;
   background: #f4f6f8;
-  border-radius: 5px;
+  border-radius: var(--radius);
 }
 
 .navbar-dropdown-list :first-child :first-child {
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
+  border-top-left-radius: var(--radius-lg);
+  border-top-right-radius: var(--radius-lg);
 }
 
 .navbar-dropdown-list :last-child :last-child {
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
+  border-bottom-left-radius: var(--radius-lg);
+  border-bottom-right-radius: var(--radius-lg);
 }
 
 .separator {
@@ -141,7 +146,7 @@
 .navbar-dropdown-list-item-link {
   color: var(--color-brand);
   display: block;
-  padding: 1rem 2rem;
+  /* padding: 1rem 2rem; */
   text-decoration: none;
 }
 
@@ -155,14 +160,9 @@
 
 .navbar-end {
   display: none;
-  margin: 1rem 0;
 }
 
-@media (min-width: 984px) {
-  .es-header {
-    padding: 1.5rem var(--grid-margin);
-  }
-
+@media (min-width: 1008px) {
   .es-navbar {
     display: flex;
     flex-direction: row;
@@ -170,36 +170,49 @@
   }
 
   .navbar-brand-wrapper {
-    margin-right: 1.5rem;
-  }
-
-  .navbar-brand {
-    padding: 0;
+    height: 2.8125rem;
+    margin-right: var(--spacing-4);
   }
 
   .navbar-list {
     display: flex;
-    margin: 0;
+    margin-top: 0;
   }
 
   .navbar-toggler {
     display: none;
   }
 
+  .navbar-list-item {
+    padding: var(--spacing-3) var(--spacing-3) var(--spacing-3) 0;
+  }
+
+  .navbar-list-item-link,
+  .navbar-list-item-dropdown-toggle {
+    padding: 0.3125rem 0 0.25rem;
+  }
+
   .navbar-list-item-link {
-    padding: 1rem 1.5rem;
+    margin-right: -0.5rem;
+    margin-left: -0.5rem;
+    padding-right: 0.5rem;
+    padding-left: 0.5rem;
   }
 
   .navbar-list-item-dropdown-toggle {
     width: auto;
-    margin: 0;
-    padding: 1rem 3.5rem 1rem 1.5rem;
-    background-position: right 1.5rem center;
+    margin-left: -0.5rem;
+    padding-right: 1rem;
+    padding-left: 0.5rem;
+    background-position: right center;
   }
 
   .navbar-dropdown-list {
-    box-shadow: 0 0 1px 0 rgba(73, 79, 95, 0.6), 0 2px 10px -5px rgba(73, 79, 95, 0.55),
-      0 3px 30px -15px rgba(73, 79, 95, 0.8), 0 0 50px -5px rgba(73, 79, 95, 0.5);
+    box-shadow: 0 0 1px 0 rgba(73, 79, 95, 0.6),
+      0 2px 10px -5px rgba(73, 79, 95, 0.55),
+      0 3px 30px -15px rgba(73, 79, 95, 0.8),
+      0 0 50px -5px rgba(73, 79, 95, 0.5);
+    width: auto;
     margin: 0;
     position: absolute;
     left: -0.5rem;
@@ -207,12 +220,10 @@
   }
 
   .navbar-dropdown-list-item-link {
-    padding-right: 3rem;
   }
 
   .navbar-end {
     display: block;
     align-self: center;
-    margin: 0 1.5rem 0 auto;
   }
 }

--- a/addon/styles/container.css
+++ b/addon/styles/container.css
@@ -1,0 +1,7 @@
+.container {
+  max-width: var(--container-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding: var(--spacing-4) var(--grid-margin);
+  box-sizing: content-box;
+}

--- a/addon/styles/flex.css
+++ b/addon/styles/flex.css
@@ -1,0 +1,9 @@
+.flex-row {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+}
+
+.justify-content-between {
+  justify-content: space-between;
+}

--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -1,6 +1,9 @@
 :root {
-  --font-family-sans: 'Inter var', 'Inter web', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  /* Vertical rhythm is based on multiples of 8. */
+
+  --font-family-sans: "Inter var", "Inter web", -apple-system,
+    BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
+    Apple Color Emoji, Segoe UI Emoji;
 
   --color-white: #fff;
   --color-gray-100: #f4f6f8;
@@ -25,68 +28,73 @@
   --color-warning: #fcffc9;
   --color-info: #e3eefc;
 
-  --font-size-xs: 1.375rem; /* 11px */
-  --font-size-base: 1.625rem; /* p = 13px */
-  --font-size-md: 1.875rem; /* h3 = 15px */
-  --font-size-lg: 2.25rem; /* h2 = 18px */
-  --font-size-xl: 3.125rem; /* h1 = 25px */
-  --font-size-display-1: 4rem; /* display 1 = 32px */
-  --font-size-display-2: 1.875rem; /* display 2 = 15px */
+  --font-size-xs: 0.8125rem; /* 13px, use sparsly! */
+  --font-size-base: 0.9375rem; /* p = 15px */
+  --font-size-md: 0.9375rem; /* h3 = 15px */
+  --font-size-lg: 1.1875rem; /* h2 = 19px */
+  --font-size-xl: 1.5625rem; /* h1 = 25px */
+  --font-size-display-1: 1.8754rem; /* display 1 = 30px */
+  --font-size-display-2: 0.9375rem; /* display 2 = 15px */
 
-  --line-height-xs: calc(16 / 11);
-  --line-height-base: calc(24 / 13);
-  --line-height-md: 1.6;
-  --line-height-lg: calc(32 / 18);
-  --line-height-xl: 1.28;
-  --line-height-display-1: 1.25;
-  --line-height-display-2: 1.6;
+  --line-height-xs: calc(16 / 13); /* 16px */
+  --line-height-base: 1.6; /* 24px */
+  --line-height-md: 1.6; /* 24px */
+  --line-height-lg: calc(24 / 19); /* 24px */
+  --line-height-xl: 2; /* 32px */
+  --line-height-display-1: calc(32 / 30); /* 32px */
+  --line-height-display-2: 1.6; /* 24px */
 
   --font-weight-1: 200;
   --font-weight-2: 400;
   --font-weight-3: 600;
 
-  --container-width: 119rem;
-  --grid-gap-x: 3rem;
-  --grid-gap-y: 6rem;
-  --grid-margin: 1.5rem;
+  --spacing-1: 0.5rem; /* 8px */
+  --spacing-2: 1rem; /* 16px */
+  --spacing-3: 1.5rem; /* 24px */
+  --spacing-4: 2.5rem; /* 40px */
+  --spacing-5: 3.5rem; /* 56px */
+  --spacing-6: 4rem; /* 64px */
 
-  --spacing-1: 1rem;
-  --spacing-2: 2rem;
-  --spacing-3: 3rem;
-  --spacing-4: 5rem;
-  --spacing-5: 8rem;
+  --container-width: 60.75rem;
+  --grid-gap-sm: var(--spacing-2);
+  --grid-gap-md: var(--spacing-3);
+  --grid-gap-lg: var(--spacing-4);
+  --grid-margin: 0.75rem;
 
-  --radius: 0.625rem;
-  --radius-lg: 1.25rem;
+  --radius: 0.3125rem;
+  --radius-lg: 0.625rem;
 }
 
-/* 984px = 2rem + 119rem + 2rem */
-@media (min-width: 984px) {
+@media (min-width: 1008px) {
+  /* Vertical rhythm is based on multiples of 9. */
+
   :root {
-    --font-size-xs: 1.5rem; /* 12px */
-    --font-size-base: 1.875rem; /* 15px */
-    --font-size-md: 2rem; /* 16px */
-    --font-size-lg: 2.5rem; /* 20px */
-    --font-size-xl: 4.5rem; /* 36px */
-    --font-size-display-1: 7.75rem; /* 62px */
-    --font-size-display-2: 2.375rem; /* 19px */
+    --font-size-xs: 0.875rem; /* 14px, use sparsly! */
+    --font-size-base: 1rem; /* 16px */
+    --font-size-md: 1.0625rem; /* 17px */
+    --font-size-lg: 1.25rem; /* 20px */
+    --font-size-xl: 2.25rem; /* 36px */
+    --font-size-display-1: 3rem; /* 48px */
+    --font-size-display-2: 1.125rem; /* 18px */
 
-    --line-height-xs: calc(16 / 12);
-    --line-height-base: 1.6;
-    --line-height-md: 1.5;
-    --line-height-lg: 1.2;
-    --line-height-xl: calc(48 / 36);
-    --line-height-display-1: calc(64 / 62);
-    --line-height-display-2: calc(32 / 19);
+    --line-height-xs: calc(16 / 14); /* 16px */
+    --line-height-base: 1.6875; /* 27px */
+    --line-height-md: calc(27 / 17); /* 27px */
+    --line-height-lg: 1.35; /* 27px */
+    --line-height-xl: 1.25; /* 45px */
+    --line-height-display-1: 1.125; /* 54px */
+    --line-height-display-2: 1.5; /* 27px */
 
-    --spacing-1: 2rem;
-    --spacing-2: 3rem;
-    --spacing-3: 6rem;
-    --spacing-4: 9rem;
-    --spacing-5: 24rem;
+    --spacing-1: 0.5625rem; /* 9px */
+    --spacing-2: 1.125rem; /* 18px */
+    --spacing-3: 1.6875rem; /* 27px */
+    --spacing-4: 2.25rem; /* 36px */
+    --spacing-5: 3.375rem; /* 54px */
+    --spacing-6: 4.5rem; /* 72px */
 
-    --grid-gap-x: 4rem;
-    --grid-gap-y: 9rem;
+    --grid-gap-sm: var(--spacing-3); /* 27px */
+    --grid-gap-md: 2.25rem; /* 36px */
+    --grid-gap-lg: var(--spacing-4); /* 54px */
   }
 }
 
@@ -103,10 +111,6 @@ html {
   background: var(--color-white);
   color: var(--color-gray-700);
   border: 0;
-}
-
-html {
-  font-size: 50%; /* 8px if using default Browser settings of 16px, while staying scalable */
 }
 
 body {

--- a/addon/styles/grid.css
+++ b/addon/styles/grid.css
@@ -1,0 +1,51 @@
+/**
+* A grid is an equally spaced matrix of items of a common type.
+* e.q. a bunch of logos, mascots, cards, etc.
+*/
+.grid {
+  --column-count: 1;
+
+  display: grid;
+  grid-template-columns: repeat(var(--column-count), 1fr);
+  grid-gap: var(--grid-gap-x);
+}
+
+.grid > * {
+  grid-column: span 1;
+}
+
+@media (max-width: 983px) {
+  .sm\:grid-2 {
+    --column-count: 2;
+  }
+
+  .sm\:grid-3 {
+    --column-count: 3;
+  }
+
+  .sm\:grid-4 {
+    --column-count: 4;
+  }
+}
+
+@media (min-width: 984px) {
+  .lg\:grid-2 {
+    --column-count: 2;
+  }
+
+  .lg\:grid-3 {
+    --column-count: 3;
+  }
+
+  .lg\:grid-4 {
+    --column-count: 4;
+  }
+
+  .lg\:grid-5 {
+    --column-count: 5;
+  }
+
+  .lg\:grid-6 {
+    --column-count: 6;
+  }
+}

--- a/addon/styles/grid.css
+++ b/addon/styles/grid.css
@@ -7,14 +7,14 @@
 
   display: grid;
   grid-template-columns: repeat(var(--column-count), 1fr);
-  grid-gap: var(--grid-gap-x);
+  grid-gap: var(--grid-gap-md);
 }
 
 .grid > * {
   grid-column: span 1;
 }
 
-@media (max-width: 983px) {
+@media (max-width: 1007px) {
   .sm\:grid-2 {
     --column-count: 2;
   }
@@ -28,7 +28,7 @@
   }
 }
 
-@media (min-width: 984px) {
+@media (min-width: 1008px) {
   .lg\:grid-2 {
     --column-count: 2;
   }
@@ -43,9 +43,7 @@
 
   .lg\:grid-5 {
     --column-count: 5;
-  }
 
-  .lg\:grid-6 {
-    --column-count: 6;
+    grid-gap: var(--grid-gap-sm);
   }
 }

--- a/addon/styles/layout.css
+++ b/addon/styles/layout.css
@@ -13,11 +13,11 @@
 .layout {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  grid-gap: var(--grid-gap-y) var(--grid-gap-x);
+  grid-gap: var(--grid-gap-md) var(--grid-gap-lg);
   grid-auto-flow: row dense;
 }
 
-@media (max-width: 983px) {
+@media (max-width: 1007px) {
   .layout > * {
     grid-column-end: span 4;
   }
@@ -55,7 +55,7 @@
   }
 }
 
-@media (min-width: 984px) {
+@media (min-width: 1008px) {
   .layout > * {
     grid-column-end: span 6;
   }

--- a/addon/styles/layout.css
+++ b/addon/styles/layout.css
@@ -12,7 +12,7 @@
 
 .layout {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   grid-gap: var(--grid-gap-md) var(--grid-gap-lg);
   grid-auto-flow: row dense;
 }
@@ -56,6 +56,10 @@
 }
 
 @media (min-width: 1008px) {
+  .layout {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
   .layout > * {
     grid-column-end: span 6;
   }

--- a/addon/styles/layout.css
+++ b/addon/styles/layout.css
@@ -1,131 +1,110 @@
-.container {
-  max-width: var(--container-width);
-  margin-left: auto;
-  margin-right: auto;
-  padding: var(--spacing-4) var(--grid-margin);
-  box-sizing: content-box;
-}
+/**
+* Layout provides a way to arrange children of different types
+* in a designed and meaningful way.
+* Each child that should not cover the full width needs
+* at least a class that specifies how many columns it will span and may
+* have an additional class that specifies the start column.
+* Columns can be reordered by specifying a start column for two elements,
+* making them start in switched places.
+*
+* The layout uses 6 columns on large and 4 columns on smaller screens.
+*/
 
-.flex-row {
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-}
-
-.justify-content-between {
-  justify-content: space-between;
-}
-
-.layout-grid {
+.layout {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   grid-gap: var(--grid-gap-y) var(--grid-gap-x);
+  grid-auto-flow: row dense;
 }
 
-.layout-grid > * {
-  grid-column: span 6 / span 6;
-}
-
-.col-1 {
-  grid-column: span 1 / span 1;
-}
-
-.col-2 {
-  grid-column: span 2 / span 2;
-}
-
-.col-3 {
-  grid-column: span 3 / span 3;
-}
-
-.col-4 {
-  grid-column: span 4 / span 4;
-}
-
-.col-5 {
-  grid-column: span 5 / span 5;
-}
-
-.col-6 {
-  grid-column: span 6 / span 6;
-}
-
-.offset-1 {
-  grid-column-start: 2;
-}
-
-.offset-2 {
-  grid-column-start: 3;
-}
-
-.offset-3 {
-  grid-column-start: 4;
-}
-
-.offset-4 {
-  grid-column-start: 5;
-}
-
-.offset-5 {
-  grid-column-start: 6;
-}
-
-@media (min-width: 576px) {
-  .col-1-large {
-    grid-column: span 1 / span 1;
+@media (max-width: 983px) {
+  .layout > * {
+    grid-column-end: span 4;
   }
 
-  .col-2-large {
-    grid-column: span 2 / span 2;
+  .layout .sm\:col-1 {
+    grid-column-end: span 1;
   }
 
-  .col-3-large {
-    grid-column: span 3 / span 3;
+  .layout .sm\:col-2 {
+    grid-column-end: span 2;
   }
 
-  .col-4-large {
-    grid-column: span 4 / span 4;
+  .layout .sm\:col-3 {
+    grid-column-end: span 3;
   }
 
-  .col-5-large {
-    grid-column: span 5 / span 5;
+  .layout .sm\:col-4 {
+    grid-column-end: span 4;
   }
 
-  .col-6-large {
-    grid-column: span 6 / span 6;
+  .layout .sm\:start-1 {
+    grid-column-start: 1;
   }
 
-  .offset-1-large {
+  .layout .sm\:start-2 {
     grid-column-start: 2;
   }
 
-  .offset-2-large {
+  .layout .sm\:start-3 {
     grid-column-start: 3;
   }
 
-  .offset-3-large {
+  .layout .sm\:start-4 {
     grid-column-start: 4;
-  }
-
-  .offset-4-large {
-    grid-column-start: 5;
-  }
-
-  .offset-5-large {
-    grid-column-start: 6;
   }
 }
 
-@media (max-width: 576px) {
-  .layout-grid {
-    grid-template-columns: repeat(4, 1fr);
+@media (min-width: 984px) {
+  .layout > * {
+    grid-column-end: span 6;
   }
 
-  .col-5 {
-    grid-column: span 4 / span 4;
+  .layout .lg\:col-1 {
+    grid-column-end: span 1;
   }
 
-  .col-6 {
-    grid-column: span 4 / span 4;
+  .layout .lg\:col-2 {
+    grid-column-end: span 2;
+  }
+
+  .layout .lg\:col-3 {
+    grid-column-end: span 3;
+  }
+
+  .layout .lg\:col-4 {
+    grid-column-end: span 4;
+  }
+
+  .layout .lg\:col-5 {
+    grid-column-end: span 5;
+  }
+
+  .layout .lg\:col-6 {
+    grid-column-end: span 5;
+  }
+
+  .layout .lg\:start-1 {
+    grid-column-start: 1;
+  }
+
+  .layout .lg\:start-2 {
+    grid-column-start: 2;
+  }
+
+  .layout .lg\:start-3 {
+    grid-column-start: 3;
+  }
+
+  .layout .lg\:start-4 {
+    grid-column-start: 4;
+  }
+
+  .layout .lg\:start-5 {
+    grid-column-start: 5;
+  }
+
+  .layout .lg\:start-6 {
+    grid-column-start: 6;
   }
 }

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -5,8 +5,8 @@ A card component that serves as a content container for images, text and links. 
 Here is an example of a card
 
 ```html
-<ul class="list-unstyled">
-  <EsCard>
+<ul class="list-unstyled layout">
+  <EsCard class="lg:col-2">
     This is a card
   </EsCard>
 </ul>
@@ -16,8 +16,8 @@ You can also add an image to the card using the `@image` parameter:
 
 
 ```html
-<ul class="list-unstyled">
-  <EsCard @image="/ember-logo.png">
+<ul class="list-unstyled layout">
+  <EsCard @image="/ember-logo.png" class="lg:col-2">
     This is a card
   </EsCard>
 </ul>
@@ -26,8 +26,8 @@ You can also add an image to the card using the `@image` parameter:
 By default images will be considered decorative and ignored by screen readers, but if you want to provide an alt text for the image you can provide it with the `@alt` parameter:
 
 ```html
-<ul class="list-unstyled">
-  <EsCard @image="/ember-logo.png" @alt="Ember Logo">
+<ul class="list-unstyled layout">
+  <EsCard @image="/ember-logo.png" @alt="Ember Logo" class="lg:col-2">
     This is a card
   </EsCard>
 </ul>
@@ -36,8 +36,8 @@ By default images will be considered decorative and ignored by screen readers, b
 By default the card will have the image to the left of the content. If you want to make the card a **vertical** card you can apply the `vertical` attribute;
 
 ```html
-<ul class="list-unstyled">
-  <EsCard @image="/ember-logo.png" vertical>
+<ul class="list-unstyled layout">
+  <EsCard class="lg:col-2" @image="/ember-logo.png" vertical>
     This is a card
   </EsCard>
 </ul>
@@ -47,11 +47,11 @@ It is unlikely that you will be using this vertical display of a card with a ful
 
 
 ```html
-<ul class="list-unstyled layout-grid">
-  <EsCard @image="/ember-logo.png" vertical class="col-2-large">
+<ul class="list-unstyled layout">
+  <EsCard @image="/ember-logo.png" vertical class="lg:col-2">
     this is a card
   </EsCard>
-  <EsCard @image="/ember-logo.png" vertical class="col-2-large">
+  <EsCard @image="/ember-logo.png" vertical class="lg:col-2">
     this is another card
   </EsCard>
 </ul>
@@ -60,11 +60,11 @@ It is unlikely that you will be using this vertical display of a card with a ful
 If you want the image to take up the full available width of the card you can apply the `full-image` attribute:
 
 ```html
-<ul class="list-unstyled layout-grid">
-  <EsCard @image="/ember-logo.png" vertical full-image class="col-2-large">
+<ul class="list-unstyled layout">
+  <EsCard @image="/ember-logo.png" vertical full-image class="lg:col-2">
     this is a card
   </EsCard>
-  <EsCard @image="/ember-logo.png" vertical full-image class="col-2-large">
+  <EsCard @image="/ember-logo.png" vertical full-image class="lg:col-2">
     this is another card
   </EsCard>
 </ul>
@@ -73,8 +73,8 @@ If you want the image to take up the full available width of the card you can ap
 And here is a fuller example of a vertical, full-image card that has more structure in the card body
 
 ```html
-<ul class="list-unstyled layout-grid">
-  <EsCard @image="/ember-logo.png" vertical full-image class="col-2-large">
+<ul class="list-unstyled layout">
+  <EsCard @image="/ember-logo.png" vertical full-image class="lg:col-2">
     <h3>Ember.js</h3>
     <p>A framework for ambitious web developers. Try it out!</p>
     <div class="flex-row justify-content-between">
@@ -89,8 +89,8 @@ You can also create a card that allows a link to an external resource using `<a 
 
 
 ```html
-<ul class="list-unstyled">
-  <EsCard @image="/images/icons/discuss-logo.svg">
+<ul class="list-unstyled layout">
+  <EsCard class="lg:col-3" @image="/images/icons/discuss-logo.svg">
     <h3>
       <a href="http://discuss.emberjs.com">Discussion Forum</a>
     </h3>
@@ -102,8 +102,8 @@ You can also create a card that allows a link to an external resource using `<a 
 But if you would like the whole card to become interactive and act as a link you can add the `card-link` attribute. This will stretch the link to be the full area of the card:
 
 ```html
-<ul class="list-unstyled">
-  <EsCard @image="/images/icons/discuss-logo.svg" card-link>
+<ul class="list-unstyled layout">
+  <EsCard class="lg:col-3" @image="/images/icons/discuss-logo.svg" card-link>
     <h3>
       <a href="http://discuss.emberjs.com">Discussion Forum</a>
     </h3>
@@ -115,14 +115,14 @@ But if you would like the whole card to become interactive and act as a link you
 And here is a full card based page layout that might be useful when building sites using this component:
 
 ```html
-<ul class="list-unstyled layout-grid">
-  <EsCard class="col-3-large" @image="/images/icons/discuss-logo.svg" card-link>
+<ul class="list-unstyled layout">
+  <EsCard class="lg:col-3" @image="/images/icons/discuss-logo.svg" card-link>
     <h3>
       <a href="http://discuss.emberjs.com">Discussion Forum</a>
     </h3>
     <p>Post and search longer-form questions in our public forum.</p>
   </EsCard>
-  <EsCard class="col-3-large" @image="/images/icons/discord-logo.svg" card-link>
+  <EsCard class="lg:col-3" @image="/images/icons/discord-logo.svg" card-link>
     <h3>
       <a href="https://discord.gg/emberjs">Discord community chat</a>
     </h3>
@@ -132,21 +132,21 @@ And here is a full card based page layout that might be useful when building sit
 
 <p class="col-6-large">Beyond our core online channels, you can dig deeper with these learning resources from the community members</p>
 
-<ul class="list-unstyled layout-grid">
-  <EsCard class="col-2-large text-center" vertical @image="/images/icons/mic-icon.svg">
+<ul class="list-unstyled layout">
+  <EsCard class="lg:col-2 text-center" vertical @image="/images/icons/mic-icon.svg">
     <h3>Podcasts</h3>
     <ul class="list-unstyled">
       <li><a href="embermap somewhere">Ember Weekly</a></li>
       <li><a href="embermap somewhere">Ember Map Podcast</a></li>
     </ul>
   </EsCard>
-  <EsCard class="col-2-large text-center" vertical @image="/images/icons/book-icon.svg">
+  <EsCard class="lg:col-2 text-center" vertical @image="/images/icons/book-icon.svg">
     <h3>Books</h3>
     <ul class="list-unstyled">
       <li><a href="embermap somewhere">Rock and Roll with Ember.js</a></li>
     </ul>
   </EsCard>
-  <EsCard class="col-2-large text-center" vertical @image="/images/icons/tv-icon.svg">
+  <EsCard class="lg:col-2 text-center" vertical @image="/images/icons/tv-icon.svg">
     <h3>Videos</h3>
     <ul class="list-unstyled">
       <li><a href="embermap somewhere">Ember Map</a></li>

--- a/docs/concepts/background-shapes.md
+++ b/docs/concepts/background-shapes.md
@@ -7,8 +7,8 @@ In the new design we have a number of background shapes that can be used to spru
 To use the "background boxes" shape then you need to use the `bg-shape-boxes` css helper as follows
 
 ```html
-<div class="layout-grid bg-shape-boxes bg-dark padding-vertical-large">
-  <div class="col-4-large offset-1-large text-center">
+<div class="layout bg-shape-boxes bg-dark padding-vertical-large">
+  <div class="lg:col-4 lg:start-2 text-center">
     <h1>Build with the teams that never stop shipping.</h1>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -16,8 +16,11 @@ To use the "background boxes" shape then you need to use the `bg-shape-boxes` cs
       every step of the way.
     </p>
   </div>
-  <div class="col-4-large offset-1-large text-center">
+  <div class="margin-large text-center">
     <h2>More stuff to show location of boxes</h2>
+  </div>
+  <div class="margin-large text-center">
+    <h2>Even more stuff to show location of boxes</h2>
   </div>
 </div>
 ```
@@ -25,8 +28,8 @@ To use the "background boxes" shape then you need to use the `bg-shape-boxes` cs
 There is an alternative "background boxes" shape that you can use with `bg-shape-boxes-bottom` that will automatically continue into the following dom node (e.g. the next div)
 
 ```html
-<div class="layout-grid bg-shape-boxes-bottom bg-dark padding-vertical-large">
-  <div class="col-4-large offset-1-large text-center">
+<div class="layout bg-shape-boxes-bottom bg-dark padding-vertical-large">
+  <div class="lg:col-4 lg:start-2 text-center margin-vertical-large">
     <h1>Build with the teams that never stop shipping.</h1>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -35,8 +38,8 @@ There is an alternative "background boxes" shape that you can use with `bg-shape
     </p>
   </div>
 </div>
-<div class="layout-grid padding-vertical-medium">
-  <div class="col-4-large offset-1-large text-center">
+<div class="layout padding-vertical-large">
+  <div class="lg:col-4 lg:start-2 text-center">
     <h2>More content to show off the shapes</h2>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -57,8 +60,8 @@ If you are using the [PageHeader component](/components/page-header/) then you w
 >
   <EsButton>Go</EsButton>
 </EsPageHeader>
-<div class="layout-grid">
-  <div class="col-4-large offset-1-large text-center">
+<div class="layout">
+  <div class="lg:col-4 lg:start-2 text-center margin-vertical-large">
     <h1>Build with the teams that never stop shipping.</h1>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -74,8 +77,8 @@ If you are using the [PageHeader component](/components/page-header/) then you w
 The other type of background shape is a "swipe" that can either be a swipe across the top of the section using `bg-shape-swipe-top` or a rectangle from the bottom of the section using `bg-shape-swipe-bottom`.
 
 ```html
-<div class="layout-grid bg-shape-swipe-top">
-  <div class="col-4-large offset-1-large text-center text-light margin-vertical-large">
+<div class="layout bg-shape-swipe-top">
+  <div class="lg:col-4 lg:start-2 text-center text-light margin-vertical-large">
     <h2>Build with the teams that never stop shipping.</h2>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -83,8 +86,12 @@ The other type of background shape is a "swipe" that can either be a swipe acros
       every step of the way.
     </p>
   </div>
-  <div class="col-4-large offset-1-large text-center margin-vertical-large">
+  <div class="text-center margin-vertical-large">
     <h2>More stuff to show location of swipe</h2>
+  </div>
+
+  <div class="text-center margin-vertical-large">
+    <h2>Even more stuff to show location of swipe</h2>
   </div>
 </div>
 ```
@@ -92,8 +99,8 @@ The other type of background shape is a "swipe" that can either be a swipe acros
 and then using the `bg-shape-swipe-bottom` we can get a shape for the bottom of a section:
 
 ```html
-<div class="layout-grid bg-dark bg-shape-swipe-bottom">
-  <div class="col-4-large offset-1-large text-center margin-vertical-large">
+<div class="layout bg-dark bg-shape-swipe-bottom">
+  <div class="lg:col-4 lg:start-2 text-center margin-vertical-large">
     <h2>Build with the teams that never stop shipping.</h2>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -101,10 +108,13 @@ and then using the `bg-shape-swipe-bottom` we can get a shape for the bottom of 
       every step of the way.
     </p>
   </div>
-  <div class="col-4-large offset-1-large text-center margin-vertical-large">
+  <div class="text-center margin-vertical-large">
     <h2>More stuff to show location of swipe</h2>
   </div>
-  <div class="col-4-large offset-1-large text-center margin-vertical-large">
+  <div class="text-center margin-vertical-large">
+    <h2>Even more stuff to show location of swipe</h2>
+  </div>
+  <div class="text-center margin-vertical-large">
     <h2>yes this needs quite a large section</h2>
   </div>
 </div>

--- a/docs/concepts/colours.md
+++ b/docs/concepts/colours.md
@@ -10,30 +10,30 @@ Website elements like text and icons should meet accesibility standards when use
 
 The primary palette is applied across every page of the website and contains the brand, accent and neutral colors. The purpose of the primary palette is to keep uniformity across all pages while encouraging accessibility best practices.
 
-<div class="layout-grid">
-  <ColorPallet class="col-2-large" @color="#E04E39" @name="Brand" @variable="--color-brand" @class-name="bg-brand"/>
-<ColorPallet class="col-2-large" @color="#FFFFFF" @name="White" @variable="--color-white" @class-name="bg-dark" />
-<ColorPallet class="col-2-large" @color="#F4F6F8" @name="Gray 100" @variable="--color-gray-100" @class-name="bg-dark" />
-<ColorPallet class="col-2-large" @color="#EBEEF2" @name="Gray 200" @variable="--color-gray-200" @class-name="bg-dark" />
-<ColorPallet class="col-2-large" @color="#DCE0E6" @name="Gray 300" @variable="--color-gray-300" @class-name="bg-dark" />
-<ColorPallet class="col-2-large" @color="#BEC4CC" @name="Gray 400" @variable="--color-gray-400" @class-name="bg-dark" />
-<ColorPallet class="col-2-large" @color="#8F949F" @name="Gray 500" @variable="--color-gray-500" @class-name="bg-dark" />
-<ColorPallet class="col-2-large" @color="#6A707A" @name="Gray 600" @variable="--color-gray-600" @class-name="bg-light" />
-<ColorPallet class="col-2-large" @color="#42474F" @name="Gray 700" @variable="--color-gray-700" @class-name="bg-light" />
-<ColorPallet class="col-2-large" @color="#2B2D34" @name="Gray 800" @variable="--color-gray-800" @class-name="bg-light" />
-<ColorPallet class="col-2-large" @color="#1C1E24" @name="Gray 900" @variable="--color-gray-900" @class-name="bg-light" />
-<ColorPallet class="col-2-large" @color="#000000" @name="Black" @variable="--color-black" @class-name="bg-light" />
+<div class="layout">
+  <ColorPallet class="lg:col-2" @color="#E04E39" @name="Brand" @variable="--color-brand" @class-name="bg-brand"/>
+<ColorPallet class="lg:col-2" @color="#FFFFFF" @name="White" @variable="--color-white" @class-name="bg-dark" />
+<ColorPallet class="lg:col-2" @color="#F4F6F8" @name="Gray 100" @variable="--color-gray-100" @class-name="bg-dark" />
+<ColorPallet class="lg:col-2" @color="#EBEEF2" @name="Gray 200" @variable="--color-gray-200" @class-name="bg-dark" />
+<ColorPallet class="lg:col-2" @color="#DCE0E6" @name="Gray 300" @variable="--color-gray-300" @class-name="bg-dark" />
+<ColorPallet class="lg:col-2" @color="#BEC4CC" @name="Gray 400" @variable="--color-gray-400" @class-name="bg-dark" />
+<ColorPallet class="lg:col-2" @color="#8F949F" @name="Gray 500" @variable="--color-gray-500" @class-name="bg-dark" />
+<ColorPallet class="lg:col-2" @color="#6A707A" @name="Gray 600" @variable="--color-gray-600" @class-name="bg-light" />
+<ColorPallet class="lg:col-2" @color="#42474F" @name="Gray 700" @variable="--color-gray-700" @class-name="bg-light" />
+<ColorPallet class="lg:col-2" @color="#2B2D34" @name="Gray 800" @variable="--color-gray-800" @class-name="bg-light" />
+<ColorPallet class="lg:col-2" @color="#1C1E24" @name="Gray 900" @variable="--color-gray-900" @class-name="bg-light" />
+<ColorPallet class="lg:col-2" @color="#000000" @name="Black" @variable="--color-black" @class-name="bg-light" />
 </div>
 
 ## Secondary Colors
 
 The secondary palette is applied to UI elements and it's not part of the base colors. The purpose of the secondary palette is to ensure the readability, usability, and accessibility of all UI elements and enhance the communication of actions, changes in state, or errors.
 
-<div class="layout-grid">
-<ColorPallet class="col-2-large" @color="#E3EEFC" @name="Color Info" @variable="--color-info" @class-name="bg-info"/>
-<ColorPallet class="col-2-large" @color="#FFD8E1" @name="Color Danger" @variable="--color-danger" @class-name="bg-danger"/>
-<ColorPallet class="col-2-large" @color="#FCFFC9" @name="Color Warning" @variable="--color-warning" @class-name="bg-warning"/>
-<ColorPallet class="col-2-large" @color="#D9F9E3" @name="Color Success" @variable="--color-success" @class-name="bg-success"/>
+<div class="layout">
+<ColorPallet class="lg:col-2" @color="#E3EEFC" @name="Color Info" @variable="--color-info" @class-name="bg-info"/>
+<ColorPallet class="lg:col-2" @color="#FFD8E1" @name="Color Danger" @variable="--color-danger" @class-name="bg-danger"/>
+<ColorPallet class="lg:col-2" @color="#FCFFC9" @name="Color Warning" @variable="--color-warning" @class-name="bg-warning"/>
+<ColorPallet class="lg:col-2" @color="#D9F9E3" @name="Color Success" @variable="--color-success" @class-name="bg-success"/>
 </div>
 
 ### Examples

--- a/docs/concepts/layout.md
+++ b/docs/concepts/layout.md
@@ -1,5 +1,6 @@
 # Layout
-The layout clases exist to maintain a consistent structure across all pages, with built-in responsive support. 
+
+The layout clases exist to maintain a consistent structure across all pages, with built-in responsive support.
 
 ## Container
 
@@ -17,12 +18,72 @@ The container is a box that wraps all content area components in a page. The mai
 This container should be used on most pages to keep content aligned with headers and footers (and other content).
 
 ## Layout
-Layout provides a way to arrange different types of content into single or multiple columns.
 
-## Common Layout Patterns
+Layout provides a way to arrange different types of content into single or multiple columns. There are currently two types of layouts in the `ember-styleguide` that have different purposes and usecases.
 
-### Center Aligned fixed width column
-Example of a centered half column. A column class is used to limit its width.
+## Layout for general pages
+
+The general layout helper is `layout` that will automatically apply a reasonable layout for most text based pages. Using the layout helper on its own will only apply spacing between elements in the page:
+
+```html
+<ul class="layout list-unstyled">
+  <EsCard>
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+  <EsCard>
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+  <EsCard>
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+  <EsCard>
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+</ul>
+```
+
+The true power of the `layout` helper is when you want to have some elements take up different widths:
+
+```html
+<ul class="layout list-unstyled">
+  <EsCard class="lg:col-3">
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+  <EsCard class="lg:col-3">
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+  <EsCard class="lg:col-2">
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+  <EsCard class="lg:col-3">
+    Some of the best development teams in the world have been iterating on their products for years with Ember. With
+    scalable UI architecture baked-in from the start, you’ll be working with the same patterns these organizations use
+    every step of the way.
+  </EsCard>
+</ul>
+```
+
+The layout is based on a 6-column layout on larger screens and 4-column on smaller screens. Anything that is prefixed with `lg:` will only apply on larger widths, so the example above will fallback to full width when viewed on smaller screens. If you want to apply column rules only on smaller screens you can use the helpers prefixed with `sm:`
+
+Now we will go through a few examples that will hopefully give you some inspiration for what you can achieve with the existing helpers.
+
+### Center-Aligned fixed-width column
+
+Here is an example of a centered element that only takes up 4 (out of the available 6) columns. A column class is used to limit its width and an offset class is used to define where it should start. **Note:** because both of these rules start with `lg:` they will not apply on mobile and it will fallback to being a full-width UI.
 
 ```html
 <div class="layout">
@@ -37,7 +98,7 @@ Example of a centered half column. A column class is used to limit its width.
 </div>
 ```
 
-### Left Aligned fixed width
+### Left-Aligned half-width
 
 ```html
 <div class="layout">
@@ -52,6 +113,7 @@ Example of a centered half column. A column class is used to limit its width.
 ```
 
 #### Column Order
+
 Columns can be reordered by specifying a start column for two elements, making them start in switched places.
 
 ```html
@@ -67,70 +129,79 @@ Columns can be reordered by specifying a start column for two elements, making t
 </div>
 ```
 
-
-### Equally Distributed Columns
+If you look at the DOM for the above example you will see that the order hasn't changed so this is essentially just a visual change. This helps with accessibility, but it also means that when you view this example on mobile the visual order will reflect the DOM order. This is particularly useful for cases where you want to alternate order of things on desktop but want the visual order to be different on mobile. View this next example on mobile to see the effect in action:
 
 ```html
-<div class="layout">
-  <div class="lg:col-2 card text-center">
-    <div class="card-content">
-      <h3>Podcasts</h3>
-      <p>Rock n' Roll with EmberJS.</p>
-    </div>
+<div class="layout">  
+  <div class="lg:col-4">
+    <h3>A Simple Component</h3>
+    <p>
+      Ember Components are a superset of HTML – that means is a full-fledged Ember Component! To pass data into
+      Components, use the @ symbol along with an argument name.
+    </p>
   </div>
-  <div class="lg:col-2 card text-center">
-    <div class="card-content">
-      <h3>Books</h3>
-      <p>Rock n' Roll with EmberJS.</p>
-    </div>
+  <img height="50px" src="/ember-logo.png" class="lg:col-2">
+  <div class="lg:col-4 lg:start-3">
+    <h3>A Simple Component</h3>
+    <p>
+      Ember Components are a superset of HTML – that means is a full-fledged Ember Component! To pass data into
+      Components, use the @ symbol along with an argument name.
+    </p>
   </div>
-  <div class="lg:col-2 card text-center">
-    <div class="card-content">
-      <h3>Videos</h3>
-      <p>Rock n' Roll with EmberJS.</p>
-    </div>
+  <img height="50px" src="/ember-logo.png" class="lg:col-2 lg:start-1">
+  <div class="lg:col-4">
+    <h3>A Simple Component</h3>
+    <p>
+      Ember Components are a superset of HTML – that means is a full-fledged Ember Component! To pass data into
+      Components, use the @ symbol along with an argument name.
+    </p>
   </div>
+  <img height="50px" src="/ember-logo.png" class="lg:col-2">
 </div>
 ```
 
+## Grid
+
+If you have elements that need a regular repeating pattern you should use the `grid` helper instead of the above layout. It is designed specifically to make sure that you can have varying number of elements that are equally spaced on each row and is more convenient to use when you know everything is going to be the same size and distribution.
+
 ```html
-<div class="layout">
-  <div class="lg:col-3 card">
-    <div class="card-content">
-      <h3>Guides</h3>
-      <p>
-        If you're familiar with JavaScript and web application development, our Guides will teach you everything you
-        need to know to get started building with Ember.
-      </p>
-    </div>
-  </div>
-  <div class="lg:col-3 card">
-    <div class="card-content">
-      <h3>Read Our Blog</h3>
-      <p>
-        Find out about the newest releases and latest work happening in the ecosystem by visiting the official Ember
-        Blog.
-      </p>
-    </div>
-  </div>
-</div>
+<ul class="grid lg:grid-3 list-unstyled">
+  <EsCard class="text-center">
+    <h3>Podcasts</h3>
+    <p>Rock n' Roll with EmberJS.</p>
+  </EsCard>
+
+  <EsCard class="text-center">
+    <h3>Books</h3>
+    <p>Rock n' Roll with EmberJS.</p>
+  </EsCard>
+
+  <EsCard class="text-center">
+    <h3>Videos</h3>
+    <p>Rock n' Roll with EmberJS.</p>
+  </EsCard>
+</ul>
 ```
 
-### Photo Grid
+You can specify the number of items per row by using anything from `lg:grid-2` to `lg:grid-5` on desktop, and `sm:grid-2` to `sm:grid-4` on mobile.
 
 ```html
-<div class="layout">
-  <div class="lg:col-2">
-    <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/400x500/000/fff" />
-  </div>
-  <div class="lg:col-2">
-    <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/500x300/000/fff" />
-    <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/600x400/000/fff" />
-  </div>
-  <div class="lg:col-2">
-    <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/400x500/000/fff" />
-  </div>
-</div>
+<ul class="grid lg:grid-2 list-unstyled">
+  <EsCard class="text-center">
+    <h3>Podcasts</h3>
+    <p>Rock n' Roll with EmberJS.</p>
+  </EsCard>
+
+  <EsCard class="text-center">
+    <h3>Books</h3>
+    <p>Rock n' Roll with EmberJS.</p>
+  </EsCard>
+
+  <EsCard class="text-center">
+    <h3>Videos</h3>
+    <p>Rock n' Roll with EmberJS.</p>
+  </EsCard>
+</ul>
 ```
 
 ## Spacing Scale

--- a/docs/concepts/layout.md
+++ b/docs/concepts/layout.md
@@ -1,8 +1,9 @@
 # Layout
+The layout clases exist to maintain a consistent structure across all pages, with built-in responsive support. 
 
 ## Container
 
-The main width of content is defined by using a `.container` CSS class. This will automatically centre content and make sure that it stays within the defined "max width" of the container. Here is an example of a dark background with some content in the middle:
+The container is a box that wraps all content area components in a page. The main width of content is defined by using a `.container` CSS class. This will automatically centre content and make sure that it stays within the defined "max width" of the container. Here is an example of a dark background with some content in the middle:
 
 ```html
 <div class="bg-dark">
@@ -15,19 +16,17 @@ The main width of content is defined by using a `.container` CSS class. This wil
 
 This container should be used on most pages to keep content aligned with headers and footers (and other content).
 
-## Grid
+## Layout
+Layout provides a way to arrange different types of content into single or multiple columns.
 
-### Grid Usage
+## Common Layout Patterns
 
-A grid can be formed with fixed boxes by arranging tiles in an inline block, icons in toolbars, etc. Column count grows with browser width. Tiles wrap to the next line, or are sometimes truncated with an overflow scroll. The column width is defined by the column classes, if no width is defined the columns will resize to fit the row.
-
-#### Center Aligned fixed width column
-
+### Center Aligned fixed width column
 Example of a centered half column. A column class is used to limit its width.
 
 ```html
-<div class="layout-grid">
-  <div class="col-4-large offset-1-large text-center">
+<div class="layout">
+  <div class="lg:col-4 lg:start-2 text-center">
     <h2>Build with the teams that never stop shipping.</h2>
     <p>
       Some of the best development teams in the world have been iterating on their products for years with Ember. With
@@ -41,8 +40,8 @@ Example of a centered half column. A column class is used to limit its width.
 ### Left Aligned fixed width
 
 ```html
-<div class="layout-grid">
-  <div class="col-3">
+<div class="layout">
+  <div class="lg:col-3">
     <h3>A Simple Component</h3>
     <p>
       Ember Components are a superset of HTML – that means is a full-fledged Ember Component! To pass data into
@@ -52,23 +51,40 @@ Example of a centered half column. A column class is used to limit its width.
 </div>
 ```
 
+#### Column Order
+Columns can be reordered by specifying a start column for two elements, making them start in switched places.
+
+```html
+<div class="layout">
+  <div class="lg:col-4 lg:start-3">
+    <h3>A Simple Component</h3>
+    <p>
+      Ember Components are a superset of HTML – that means is a full-fledged Ember Component! To pass data into
+      Components, use the @ symbol along with an argument name.
+    </p>
+  </div>
+  <div class="lg:col-2 lg:start-1 bg-brand"></div>
+</div>
+```
+
+
 ### Equally Distributed Columns
 
 ```html
-<div class="layout-grid">
-  <div class="col-2-large card text-center">
+<div class="layout">
+  <div class="lg:col-2 card text-center">
     <div class="card-content">
       <h3>Podcasts</h3>
       <p>Rock n' Roll with EmberJS.</p>
     </div>
   </div>
-  <div class="col-2-large card text-center">
+  <div class="lg:col-2 card text-center">
     <div class="card-content">
       <h3>Books</h3>
       <p>Rock n' Roll with EmberJS.</p>
     </div>
   </div>
-  <div class="col-2-large card text-center">
+  <div class="lg:col-2 card text-center">
     <div class="card-content">
       <h3>Videos</h3>
       <p>Rock n' Roll with EmberJS.</p>
@@ -78,8 +94,8 @@ Example of a centered half column. A column class is used to limit its width.
 ```
 
 ```html
-<div class="layout-grid">
-  <div class="col-3-large card">
+<div class="layout">
+  <div class="lg:col-3 card">
     <div class="card-content">
       <h3>Guides</h3>
       <p>
@@ -88,7 +104,7 @@ Example of a centered half column. A column class is used to limit its width.
       </p>
     </div>
   </div>
-  <div class="col-3-large card">
+  <div class="lg:col-3 card">
     <div class="card-content">
       <h3>Read Our Blog</h3>
       <p>
@@ -103,15 +119,15 @@ Example of a centered half column. A column class is used to limit its width.
 ### Photo Grid
 
 ```html
-<div class="layout-grid">
-  <div class="col-2-large">
+<div class="layout">
+  <div class="lg:col-2">
     <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/400x500/000/fff" />
   </div>
-  <div class="col-2-large">
+  <div class="lg:col-2">
     <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/500x300/000/fff" />
     <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/600x400/000/fff" />
   </div>
-  <div class="col-2-large">
+  <div class="lg:col-2">
     <img class="img-fluid margin-bottom-small" src="https://dummyimage.com/400x500/000/fff" />
   </div>
 </div>
@@ -122,36 +138,36 @@ Example of a centered half column. A column class is used to limit its width.
 The spacing scale is used to manage spacing a white-space within layouts and components.
 The spacing scale can be applied to both margin and padding properties.
 
-<div class="layout-grid">
-  <div class="card col-1">
+<div class="layout">
+  <div class="card lg:col-1">
     <div class="spacer-xsmall bg-brand">
     </div>
     <div class="card-content">
       <h4>Extra Small Offset</h4>
     </div>
   </div>
-  <div class="card col-1">
+  <div class="card lg:col-1">
     <div class="spacer-small bg-brand">
     </div>
     <div class="card-content">
       <h4>Small Offset</h4>
     </div>
   </div>
-  <div class="card col-1">
+  <div class="card lg:col-1">
     <div class="spacer-medium bg-brand">
     </div>
     <div class="card-content">
       <h4>Medium Offset</h4>
     </div>
   </div>
-  <div class="card col-1">
+  <div class="card lg:col-1">
     <div class="spacer-large bg-brand">
     </div>
     <div class="card-content">
       <h4>Large Offset</h4>
     </div>
   </div>
-  <div class="card col-1">
+  <div class="card lg:col-1">
     <div class="spacer-xlarge bg-brand">
     </div>
     <div class="card-content">


### PR DESCRIPTION
I had a bit of trouble with this one, as most of its changes are entangled into each other, which made it hard to separate. 

This replaces the previously available `.layout-grid` class into two separate helpers, one for `.layout` which allows for lay outing content in an editorial way (columns, reordering, skipping columns) and `.grid`, which provides a very clean way to displaying a list of similar contents (think logos, cards, …) in an equally spaced grid.

Closes #237  (no longer required, now a basic feature of `.layout`)
Re #235 (we still need much more documentation, but I ran out of time for today)

This also revisits all font sizes and vertical rhythms and increases the font size for desktop user to 16px. It also changes the base unit for `1rem` to the browser default of 16px as I have experienced problems with changing that value in other places. It also helps to keep things as expected if something needs to be changed.

Closes #242 

It also updates the `<EmHeader>` component to the new spacings.