### PR TITLE
make hide-on-mobile !important

### DIFF
--- a/addon/styles/helpers/index.css
+++ b/addon/styles/helpers/index.css
@@ -15,6 +15,6 @@
 
 @media (max-width: 1007px) {
   .hide-on-mobile {
-    display: none;
+    display: none !important;
   }
 }


### PR DESCRIPTION
This is adding `!important` to the `.hide-on-mobile` helper so that it can override any display attributes on application css 👍 