### PR TITLE
Fix dark card hover

### DIFF
--- a/addon/styles/components/es-card.css
+++ b/addon/styles/components/es-card.css
@@ -27,6 +27,11 @@
   background-color: var(--color-gray-200);
 }
 
+.bg-dark .card[card-link]:focus-within,
+.bg-dark .card[card-link]:hover {
+  background-color: var(--color-gray-800);
+}
+
 .card__image {
   display: block;
   max-width: 64px;

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -109,6 +109,21 @@ But if you would like the whole card to become interactive and act as a link you
 </ul>
 ```
 
+Here is what that looks like on a dark background
+
+```html
+<div class="bg-dark">
+  <ul class="list-unstyled layout">
+    <EsCard class="lg:col-3" @image="/images/icons/mic-icon.svg" card-link>
+      <h3>
+        <a href="http://discuss.emberjs.com">Discussion Forum</a>
+      </h3>
+      <p>Post and search longer-form questions in our public forum.</p>
+    </EsCard>
+  </ul>
+</div>
+```
+
 And here is a full card based page layout that might be useful when building sites using this component:
 
 ```html


### PR DESCRIPTION
The hover state of the card on a light background was fine but we need a different shade when on a dark background.

Before: 
<img width="633" alt="Screenshot 2020-01-16 at 22 16 56" src="https://user-images.githubusercontent.com/594890/72567504-ee7eb380-38ad-11ea-8b94-daa15c7240d1.png">

After: 
<img width="725" alt="Screenshot 2020-01-16 at 22 15 13" src="https://user-images.githubusercontent.com/594890/72567484-e292f180-38ad-11ea-9796-8043c66adcd9.png">
