### PR TITLE
Fix axe warnings

### DIFF
--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -72,7 +72,7 @@
   --color-button-text: var(--color-white);
   --color-button-bg: var(--color-brand);
   --color-button-bg-hover: var(--color-brand-hc-dark);
-  --color-button-secondary-text: var(--color-brand);
+  --color-button-secondary-text: var(--color-brand-hc-dark);
   --color-button-secondary-bg: var(--color-white);
   --color-button-secondary-bg-hover: var(--color-brand);
   --color-button-secondary-text-hover: var(--color-white);

--- a/public/images/swipe-top.svg
+++ b/public/images/swipe-top.svg
@@ -1,6 +1,6 @@
 <svg width="1200" height="350" xmlns="http://www.w3.org/2000/svg">
   <path fill="url(#Pattern)" fill-rule="nonzero" d="M 1200 350 V 0 L 0 350 z"/>
-  <circle fill="e04e39" cx="25" cy="75" r="1"/>
+
   <pattern id="Pattern" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
     <rect x="0" y="0" width="30" height="30" fill="#f4f6f8"/>
     <circle cx="15" cy="15" r="1" fill="#e04e39" />


### PR DESCRIPTION
This is only fixing the colour contrast for secondary buttons. I also added a tiny fix to remove a stray "dot" in the swipe-top svg while I was here