### PR TITLE
Remove isDevelopingAddon from the addon config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,6 @@ const PresetEnv = require('postcss-preset-env');
 module.exports = {
   name: require('./package').name,
 
-  isDevelopingAddon() {
-    return true;
-  },
-
   options: {
     postcssOptions: {
       compile: {


### PR DESCRIPTION
Having `isDevelopingAddon` set to true when we publish the package causes template errors to show up on the consuming app's build output. 

Resolves #289.