### PR TITLE
Update @ember/render-modifiers to 1.0.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3361,12 +3361,12 @@
       }
     },
     "@ember/render-modifiers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.0.tgz",
-      "integrity": "sha512-TqUW7exzLUwnzqHqKbo5ui0rvrS/YkbRlFD+h07kDYVFJkS2uPwkQE/K4YDeTywqN6er7VamFwl7Og98sPjmiQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
       "requires": {
-        "ember-cli-babel": "^7.1.2",
-        "ember-modifier-manager-polyfill": "^1.0.1"
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
       }
     },
     "@ember/test-helpers": {
@@ -13188,11 +13188,11 @@
       }
     },
     "ember-modifier-manager-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz",
-      "integrity": "sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
       "requires": {
-        "ember-cli-babel": "^7.4.2",
+        "ember-cli-babel": "^7.10.0",
         "ember-cli-version-checker": "^2.1.2",
         "ember-compatibility-helpers": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@ember/render-modifiers": "^1.0.0",
+    "@ember/render-modifiers": "^1.0.2",
     "broccoli-funnel": "^3.0.2",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-postcss": "^5.1.0",


### PR DESCRIPTION
This fixes an issue with failures on 3.19+ due to the removal of a private API deprecation (modifier managers not having a `capabilities` field).