### PR TITLE
Fix the "tag line"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16912,9 +16912,9 @@
       }
     },
     "field-guide-default-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/field-guide-default-template/-/field-guide-default-template-1.1.0.tgz",
-      "integrity": "sha512-o8sx2g0w4xpqUOF/HWWWaINkzbygB+sjp1OIEqrnLc5yn9Ah7ib8w5f+DyWBAMFlibuqWrWGjXQkdhQNSCvUwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/field-guide-default-template/-/field-guide-default-template-1.2.0.tgz",
+      "integrity": "sha512-j77zVklzlpIRSh1trFinBecH0A0rPZSDeYV9XzeHNYj8nswCpPwx36G0UCEy0CFoTfv1lAu6Gldzd/yry3zjwQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.7.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-ember": "^7.10.1",
     "eslint-plugin-node": "^11.0.0",
     "field-guide": "^1.0.4",
-    "field-guide-default-template": "^1.1.0",
+    "field-guide-default-template": "^1.2.0",
     "loader.js": "^4.7.0",
     "np": "*",
     "npm-run-all": "^4.1.5",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -28,6 +28,7 @@ module.exports = function(environment) {
 
     'field-guide': {
       name: 'Ember',
+      tagLine: 'Ember Styleguide',
       logo: '/ember-logo.png',
       copyright: 'Ember Field Guide is designed to document the [ember-styleguide](https://github.com/ember-learn/ember-styleguide) project. For more information view the readme',
       github: 'https://github.com/ember-learn/ember-styleguide'


### PR DESCRIPTION
This fixes the tag line under the logo, changes it from `Ember Field Guide` to `Ember Styleguide` 🎉 

Fixes #314 