### PR TITLE
fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
   # so that your addon works for all apps
   - "10"
 
-dist: trusty
-
 addons:
   chrome: stable
 


### PR DESCRIPTION
The test system has suddenly stopped working because we have a very out dated Chrome install. This is because of https://travis-ci.community/t/you-can-no-longer-install-chrome-stable-on-trusty-machines/8521

We just need to use the default that travis provide (by removing the trusty config)