### PR TITLE
fix issue with building addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
     return staticPostcssAddonTree(tree, {
       addonName: 'ember-styleguide',
       addonFolder: __dirname,
-      project: this.app.project
+      project: this.project || this.app.project
     });
   },
 


### PR DESCRIPTION
I'm not entirely sure what is going on here but the floating dependency check on empress-blog-ember-template is failing because of this issue 🙃  https://travis-ci.org/github/ember-learn/empress-blog-ember-template/jobs/706485322

Something changed but I'm not sure what. I'm going to release this pretty quickly to unblock the blog work, but we should probably get to the bottom of the issue at some point