### PR TITLE
h4 and h5 style fixes

### DIFF
--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -190,9 +190,10 @@ h3,
 h4,
 h5,
 h6 {
-  font-weight: var(--font-weight-2);
+  font-weight: var(--font-weight-3);
   margin: 0 0 2rem 0;
   color: var(--color-gray-900);
+  font-size: inherit;
 }
 
 strong {


### PR DESCRIPTION
- h4 and h5 were not being distinguished from regular text in a meaningful way as described in https://github.com/ember-learn/ember-styleguide/pull/335
- this attmepts to fix the size and weight of these styles

Co-Authored-By: Chris Manson <mansona@users.noreply.github.com>