### PR TITLE
fix image constraints

### DIFF
--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -244,6 +244,10 @@ blockquote:before {
   top: var(--spacing-1);
 }
 
+img {
+  max-width: 100%;
+}
+
 /*
 @media (max-width: 1280px) and (min-width: 421px) {
   body,


### PR DESCRIPTION
- images in markdown breakout of their container as described in https://github.com/ember-learn/ember-styleguide/pull/335
- this sets a max width to constrain them

Co-Authored-By: Chris Manson <mansona@users.noreply.github.com>