### PR TITLE
Drop jobs.emberjs.com from the community menu

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -84,10 +84,6 @@ export default [{
     name: 'Meetups',
     type: 'link'
   }, {
-    href: 'http://jobs.emberjs.com/',
-    name: 'Job Board',
-    type: 'link'
-  }, {
     type: 'divider'
   }, {
     href: 'http://emberconf.com/',


### PR DESCRIPTION
The Ember jobs board provided a valuable source of revenue to the
project for a long time. However, today the steering committee finds
that it is rarely the best place to find work in Ember, and additionally
that offerings like OpenCollective have largely supplanted its role in
generating (very modest, trust me) revenue.

As such, we're removing it from the website header. This doesn't
preclude adding new content about "Finding a Job in Ember" at some
point in the future, but in the short term we want to start the process
of mothballing the current jobs site.