### PR TITLE
fix broken import from unused file

### DIFF
--- a/app/templates/components/es-navbar.js
+++ b/app/templates/components/es-navbar.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-styleguide/templates/components/es-navbar';


### PR DESCRIPTION
This seems to be a leftover file that's unused. When running in its most-compatible mode, embroider will try to pick this file up and error because it contains a broken import statement.