### PR TITLE
Update CSS class name in `button` documentation

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -33,7 +33,7 @@ To add interactivity you can pass an action to `onClicked`
 ```
 
 ## Styling Links
-It is also possible to style a link to look like a button using the `something` class
+It is also possible to style a link to look like a button using the `es-button` or `es-button-secondary` class.
 
 ```html
 <a href="https://emberjs.com" class="es-button">Go to Ember homepage</a>


### PR DESCRIPTION
Replace `something` with "`es-button` or `es-button-secondary`"

Fixes #351

## Screenshot

![image](https://user-images.githubusercontent.com/127994/95739200-771d5b00-0c58-11eb-800b-fd9799182a27.png)

