### PR TITLE
fix .grid class column-count var taking precedence in safari

### DIFF
--- a/addon/styles/grid.css
+++ b/addon/styles/grid.css
@@ -16,33 +16,33 @@
 }
 
 @media (max-width: 1007px) {
-  .sm\:grid-2 {
+  .grid.sm\:grid-2 {
     --column-count: 2;
   }
 
-  .sm\:grid-3 {
+  .grid.sm\:grid-3 {
     --column-count: 3;
   }
 
-  .sm\:grid-4 {
+  .grid.sm\:grid-4 {
     --column-count: 4;
   }
 }
 
 @media (min-width: 1008px) {
-  .lg\:grid-2 {
+  .grid.lg\:grid-2 {
     --column-count: 2;
   }
 
-  .lg\:grid-3 {
+  .grid.lg\:grid-3 {
     --column-count: 3;
   }
 
-  .lg\:grid-4 {
+  .grid.lg\:grid-4 {
     --column-count: 4;
   }
 
-  .lg\:grid-5 {
+  .grid.lg\:grid-5 {
     --column-count: 5;
 
     grid-gap: var(--grid-gap-sm);


### PR DESCRIPTION
In Safari it seems that in certain situations the `--column-count: 1;` from the .grid class takes precedence over the media query ones. As the responsive classes can't be used without the main .grid classes anyway this PR should prevent that from happening.