### PR TITLE
Adds browser support page link

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -50,6 +50,10 @@ export default [{
     name: 'Editions',
     type: 'link'
   }, {
+    href: 'https://emberjs.com/browser-support',
+    name: 'Browser Support',
+    type: 'link'
+  }, {
     href: 'https://deprecations.emberjs.com',
     name: 'Deprecations',
     type: 'link'


### PR DESCRIPTION
Adds a browser support policy page link, as described in the [new browser support policy RFC](https://github.com/emberjs/rfcs/blob/master/text/0685-new-browser-support-policy.md). PRs this to a new v4.x branch that I created, so we can release this in v4 since the Ember website is currently using v4.