### PR TITLE
Update URL for teams route

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -94,7 +94,7 @@ export default [{
   name: 'About',
   type: 'dropdown',
   items: [{
-    href: 'https://emberjs.com/team',
+    href: 'https://emberjs.com/teams',
     name: 'The Team',
     type: 'link'
   }, {


### PR DESCRIPTION
## Background

In https://github.com/ember-learn/ember-website/pull/738, I updated the route name `team` to `teams` so that the `app/router.js` file will follow Ember's conventions:

```javascript
// Before
this.route('team', { path: 'teams' });
this.route('team-redirect', { path: 'team' });

// After
this.route('team-redirect', { path: 'team' });
this.route('teams');
```

By following the conventions, I think we can help new contributors more readily understand the routing structure.

Currently, `ember-website` is able to continue to allow the header links from `ember-styleguide`—namely, `https://emberjs.com/team`. It does so by replacing the URL with `https://emberjs.com/teams` before rendering the links.


## Description

In this pull request, I updated the URL so that we don't have to replace the URL in `ember-website`.

I targeted the `v4.x` branch because `ember-website` and other project(s) (e.g. `deprecation-guide`) don't use `v5` of `ember-styleguide` yet.