### PR TITLE
Remove RFC tracking link

### DIFF
--- a/addon/constants/links.js
+++ b/addon/constants/links.js
@@ -53,10 +53,6 @@ export default [{
     href: 'https://deprecations.emberjs.com',
     name: 'Deprecations',
     type: 'link'
-  }, {
-    href: 'https://github.com/emberjs/rfc-tracking/issues',
-    name: 'RFC Tracking',
-    type: 'link'
   }]
 }, {
   href: 'https://blog.emberjs.com',


### PR DESCRIPTION
Practically speaking the RFC Tracking project has not been in use for some quite.
Linking to it does the project a disservice as it paints a picture of inactivity which is not accurate.