### PR TITLE
make sidebar wider to better match its contents' requirements

### DIFF
--- a/addon/styles/sidebar-container.css
+++ b/addon/styles/sidebar-container.css
@@ -14,8 +14,8 @@
 
 @media (min-width: 769px) {
   .sidebar-container > .es-sidebar {
-    width: 234px;
-    margin-right: 32px;
+    width: 16rem;
+    margin-right: 2rem;
     flex-grow: 0;
   }
 
@@ -26,6 +26,6 @@
   .sidebar-container > * + .es-sidebar {
     order: 999;
     margin-right: unset;
-    margin-left: 32px;
+    margin-left: 2rem;
   }
 }

--- a/tests/integration/components/es-sidebar-test.js
+++ b/tests/integration/components/es-sidebar-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | es-sidebar', function (hooks) {
     `);
 
     assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '234px',
+      width: '256px',
     });
 
     await render(hbs`
@@ -47,10 +47,10 @@ module('Integration | Component | es-sidebar', function (hooks) {
     `);
 
     assert.dom('[data-test-content-left]').hasStyle({
-      width: '706px',
+      width: '684px',
     });
     assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '234px',
+      width: '256px',
       margin: '0px 0px 0px 32px',
     });
 
@@ -62,11 +62,11 @@ module('Integration | Component | es-sidebar', function (hooks) {
     `);
 
     assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '234px',
+      width: '256px',
       margin: '0px 32px 0px 0px',
     });
     assert.dom('[data-test-content-right]').hasStyle({
-      width: '706px',
+      width: '684px',
     });
   });
 });


### PR DESCRIPTION
The current width that was set a long time ago for the Blog implementation of the sidebar is not suitable for for example the guides. It also improves display of the sidebar in the Blog in case of long titles (e.g. ember times).