### PR TITLE
Add a background color to inline code

### DIFF
--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -274,3 +274,12 @@ img {
   padding-bottom: 8rem;
   border: 1px solid #ccc;
 }
+
+code:not([class*="language-"]) {
+  background-color: var(--color-gray-400);
+  color: var(--color-black);
+  border-radius: 3px;
+  font-size: .9em;
+  padding: .2em .5em;
+  margin: 0 .1em;
+}

--- a/docs/concepts/markdown.md
+++ b/docs/concepts/markdown.md
@@ -38,6 +38,10 @@ Sometimes you just want to be **bold with your words**! But other times _you mig
 
 [Ember is the best framework](https://emberjs.com)
 
+##### Inline code
+
+Let's refer to some libraries like `ember-cli` and make sure the inline code styles are applied.
+
 --- 
 
 ![Zoey Mascot](/images/mascots/zoey.png)


### PR DESCRIPTION
Closes #380 

Merging this PR fixes a problem where the Ember Blog has no styling for inline code. The only clue that they are code is the monospace font.

<img width="725" alt="Screen Shot 2021-04-15 at 9 50 21 AM" src="https://user-images.githubusercontent.com/16627268/114881878-66010280-9dd1-11eb-971f-f4bb8cd0d328.png">

Previously, there was zero contrast on these elements. This current attempt could use some accessibility improvements, but it could be merged as a stop gap.
