### PR TITLE
Add node: current to targets for dummy app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "ember-qunit": "^5.1.2",
         "ember-resolver": "^8.0.2",
         "ember-sinon": "^2.2.0",
-        "ember-source": "~3.25.1",
+        "ember-source": "~3.25.4",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^2.18.1",
         "ember-try": "^1.4.0",
@@ -2785,9 +2785,9 @@
       }
     },
     "node_modules/@glimmer/vm-babel-plugins": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.74.2.tgz",
-      "integrity": "sha512-DLIKzim7Fg3o54EPgz/wsEiLOUcg24P4WJ9AAv4xsXfBmFndkEDzq1oJ3SPhB167Vp1m+GKOlfKzFm9mxX5rdA==",
+      "version": "0.77.5",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz",
+      "integrity": "sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==",
       "dev": true,
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
@@ -15512,16 +15512,16 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.1.tgz",
-      "integrity": "sha512-WCQV3FqbXRkYAwrwLZ6QcHZcTjT9ESa9H8Il+5H0QmDxLPiFnaj/UW4YLgZZ64X9PBT9WCUzLeLcccIFoFFm7w==",
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.4.tgz",
+      "integrity": "sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-transform-block-scoping": "^7.8.3",
         "@babel/plugin-transform-object-assign": "^7.8.3",
         "@ember/edition-utils": "^1.2.0",
-        "@glimmer/vm-babel-plugins": "0.74.2",
+        "@glimmer/vm-babel-plugins": "0.77.5",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
         "broccoli-concat": "^4.2.4",
@@ -37908,9 +37908,9 @@
       }
     },
     "@glimmer/vm-babel-plugins": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.74.2.tgz",
-      "integrity": "sha512-DLIKzim7Fg3o54EPgz/wsEiLOUcg24P4WJ9AAv4xsXfBmFndkEDzq1oJ3SPhB167Vp1m+GKOlfKzFm9mxX5rdA==",
+      "version": "0.77.5",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz",
+      "integrity": "sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==",
       "dev": true,
       "requires": {
         "babel-plugin-debug-macros": "^0.3.4"
@@ -48857,16 +48857,16 @@
       }
     },
     "ember-source": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.1.tgz",
-      "integrity": "sha512-WCQV3FqbXRkYAwrwLZ6QcHZcTjT9ESa9H8Il+5H0QmDxLPiFnaj/UW4YLgZZ64X9PBT9WCUzLeLcccIFoFFm7w==",
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.4.tgz",
+      "integrity": "sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-transform-block-scoping": "^7.8.3",
         "@babel/plugin-transform-object-assign": "^7.8.3",
         "@ember/edition-utils": "^1.2.0",
-        "@glimmer/vm-babel-plugins": "0.74.2",
+        "@glimmer/vm-babel-plugins": "0.77.5",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
         "broccoli-concat": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ember-qunit": "^5.1.2",
     "ember-resolver": "^8.0.2",
     "ember-sinon": "^2.2.0",
-    "ember-source": "~3.25.1",
+    "ember-source": "~3.25.4",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.18.1",
     "ember-try": "^1.4.0",

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -15,4 +15,5 @@ if (isCI || isProduction) {
 
 module.exports = {
   browsers,
+  node: 'current',
 };


### PR DESCRIPTION
This should address the issue with https://github.com/ember-learn/ember-styleguide/issues/386 

I also needed to bump the ember-source version because there was a patch version of 3.25 that fixed an underlying issue of the ember-source code not transpiling correctly for fastboot https://github.com/emberjs/ember.js/pull/19397

I have verified that this fix does solve the issue locally 👍 

Closes https://github.com/ember-learn/ember-styleguide/issues/386
Closes https://github.com/ember-learn/ember-styleguide/pull/387