### PR TITLE
fix htmlSafe import

### DIFF
--- a/addon/services/progress.js
+++ b/addon/services/progress.js
@@ -1,5 +1,5 @@
 import Service, { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 


### PR DESCRIPTION
This is fixing the htmlSafe import as described here https://deprecations.emberjs.com/v3.x#toc_ember-string-htmlsafe-ishtmlsafe

I think this is also causing issues in Ember 3.27 because of module issues 🤔 