### PR TITLE
Fix Heroku footer link

### DIFF
--- a/addon/constants/es-footer.js
+++ b/addon/constants/es-footer.js
@@ -26,7 +26,7 @@ const contributorLinks = [{
 }, {
   name: 'Hosted by:',
   title: "Heroku",
-  href: 'https://www.heroku.com/emberjs',
+  href: 'https://www.heroku.com/',
   class: 'heroku-logo',
 }, {
   name: 'CDN provided by:',


### PR DESCRIPTION
Sadly https://www.heroku.com/emberjs is now a 404