### PR TITLE
Use CSS instead of utility classes from ESNote - to allow HTML to be backwards compatible

### DIFF
--- a/addon/components/es-note.hbs
+++ b/addon/components/es-note.hbs
@@ -1,11 +1,9 @@
-<div class="cta-note" ...attributes>
-  <div class="cta-note-content">
-    <div class="cta-note-body p-2">
-      <div class="text-lg mb-1 hide-in-percy" data-test-es-note-heading>{{this.mascot.name}} says...</div>
-      <div class="cta-note-message">
-        {{yield}}
-      </div>
+<div class="cta" ...attributes>
+  <div class="cta-note">
+    <div class="cta-note-body">
+      <div class="cta-note-heading" data-test-es-note-heading>{{this.mascot.name}} says...</div>
+      <div class="cta-note-message">{{yield}}</div>
     </div>
-    <img src={{this.mascot.image}} role="presentation" alt="" class="hide-in-percy cta-mascot m-2">
+    <img src={{this.mascot.image}} role="presentation" alt="">
   </div>
 </div>

--- a/addon/styles/components/es-note.css
+++ b/addon/styles/components/es-note.css
@@ -1,4 +1,4 @@
-.cta-note {
+.cta {
   background-color: var(--color-gray-200);
   border: 2px solid var(--color-gray-600);
   border-radius: var(--radius-lg);
@@ -6,11 +6,31 @@
   max-width: 90%;
 }
 
-.cta-note .cta-note-content {
+.cta .cta-note {
   display: flex;
   justify-content: space-between;
 }
 
-.cta-note .cta-mascot {
+.cta-note .cta-note-body {
+  padding: var(--spacing-2);
+}
+
+.cta-note .cta-note-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-3);
+  line-height: var(--line-height-lg);
+  margin-bottom: var(--spacing-1);
+}
+
+.cta-note img {
+  margin: var(--spacing-2);
   transform: rotate(15deg);
 }
+
+@media only percy {
+  .cta-note .cta-note-heading,
+  .cta-note img {
+    visibility: hidden;
+  }
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ember-styleguide",
       "version": "7.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
fixes: https://github.com/ember-learn/ember-styleguide/issues/405