### PR TITLE
Creates banner with the same style as on the current website

### DIFF
--- a/addon/components/es-banner.hbs
+++ b/addon/components/es-banner.hbs
@@ -1,0 +1,6 @@
+<div
+  class="es-banner"
+  data-test-es-banner
+>
+  {{yield}}
+</div>

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -19,6 +19,7 @@
 @import 'helpers/index.css';
 
 /* Components */
+@import 'components/es-banner.css';
 @import 'components/es-button.css';
 @import 'components/es-card.css';
 @import 'components/es-footer.css';

--- a/addon/styles/components/es-banner.css
+++ b/addon/styles/components/es-banner.css
@@ -1,0 +1,41 @@
+.es-banner {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--color-brand-hc-dark);
+  padding: 8px 8px 10px;
+  color: var(--color-white);
+}
+
+.es-banner a, .es-banner a:link, .es-banner a:visited {
+  color: var(--color-white);
+  text-decoration: none;
+  border-bottom: 1px solid var(--color-white-40);
+  background: none;
+  font-size: 16px;
+  line-height: 15px;
+}
+
+.es-banner a:hover, .es-banner a:focus {
+  border-bottom: 1px solid var(--color-white);
+}
+
+.es-banner a + a {
+  margin-left: 20px;
+  position: relative;
+}
+
+.es-banner a + a::before {
+  content: '';
+  width: 3px;
+  height: 3px;
+  background: var(--color-white);
+  border-radius: 50%;
+  top: 50%;
+  transform: translateY(-50%) translateX(-50%);
+  display: block;
+  left: -10px;
+  pointer-events: none;
+  position: absolute;
+}

--- a/app/components/es-banner.js
+++ b/app/components/es-banner.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-styleguide/components/es-banner';

--- a/docs/components/banner.md
+++ b/docs/components/banner.md
@@ -1,0 +1,17 @@
+# Banner
+
+## Usage
+
+A banner will be shown at the top of the page. That can be filled with text.
+```handlebars
+<EsBanner>Some content goes here</EsBanner>
+```
+The banner can also contain a link.
+```handlebars
+<EsBanner><a href="#">Visit Website</a></EsBanner>
+```
+
+When you pass multiple links into the component they will be separated by a tiny dot.
+```handlebars
+<EsBanner><a href="#">Visit Website</a><a href="#">Visit Something else</a></EsBanner>
+```

--- a/tests/integration/components/es-banner-test.js
+++ b/tests/integration/components/es-banner-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | es-banner', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <EsBanner>
+        I have an announcement to make
+      </EsBanner>
+    `);
+
+    assert
+      .dom('[data-test-es-banner]')
+      .hasText('I have an announcement to make', 'We see the correct message');
+  });
+});


### PR DESCRIPTION
Fixes #371

This implements the banner in the same way it's currently implemented on the website. The only difference is that the banner is **dismissible** on mobile. Because I thought it weird that that should not be the case.

<img width="689" alt="Screenshot 2022-05-10 at 09 13 28" src="https://user-images.githubusercontent.com/5811560/167571059-32284367-44bb-40ec-9ef6-e2a2aac61d78.png">

