### PR TITLE
add permissions for continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
     name: ${{ matrix.try-scenario }} - Allowed to fail
     runs-on: ubuntu-latest
     needs: 'test'
+    permissions:
+      pull-requests: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
So... turns out github action permissions are quite complicated 🙈 it seems like the `continue-on-error-comment` thing that should be working for all PRs isn't allowed to be used for dependabot. 

You can see that it's failing here: https://github.com/ember-learn/ember-styleguide/actions/runs/4346537705/jobs/7592840959 with the message: 

```
Error: Resource not accessible by integration
```

I did some investigation and it looks like this change should fix it, but it's going to be a bit trial and error 🤷 

Edit: It still failed with 

```
    permissions:
      issues: write
```

but now works with 

```
    permissions:
      pull-requests: write
```

so I think this is going to work 👍 I'll merge this and rebase a dependabot PR and we'll see if it fixes it