### PR TITLE
Add @ember/string to ember-release dependencies

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -43,6 +43,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
+            '@ember/string': '*',
           },
           overrides: {
             'ember-source': '$ember-source',


### PR DESCRIPTION
ember-release was failing because of this, previously already added for beta and canary.

Maybe we should consider adding it to the default dependencies, since we'll only be getting this more from here on out.