### PR TITLE
make sidebar content slightly wider and add background colour

### DIFF
--- a/addon/styles/components/es-sidebar.css
+++ b/addon/styles/components/es-sidebar.css
@@ -13,7 +13,12 @@
   border-right: 2px solid var(--color-gray-300);
 }
 
-@media (max-width: 844px) {
+.es-sidebar {
+  padding: var(--spacing-4) var(--spacing-2);
+  background-color: var(--color-gray-200);
+}
+
+@media (width <= 844px) {
   .es-sidebar-toggle {
     position: fixed;
     z-index: 1;

--- a/addon/styles/components/es-sidebar.css
+++ b/addon/styles/components/es-sidebar.css
@@ -14,7 +14,6 @@
 }
 
 .es-sidebar {
-  padding: var(--spacing-4) var(--spacing-2);
   background-color: var(--color-gray-200);
 }
 

--- a/addon/styles/sidebar-container.css
+++ b/addon/styles/sidebar-container.css
@@ -1,5 +1,5 @@
 :root {
-  --sidebar-width: 18.5rem;
+  --sidebar-width: 21rem;
 }
 
 .sidebar-container {

--- a/addon/styles/sidebar-container.css
+++ b/addon/styles/sidebar-container.css
@@ -11,6 +11,10 @@
   padding: var(--spacing-6) var(--grid-margin);
 }
 
+.sidebar-container > *:not(.es-sidebar-toggle) {
+  padding: var(--spacing-4) var(--spacing-2);
+}
+
 .sidebar-container > *:not(.es-sidebar):not(.es-sidebar-toggle) {
   grid-column: 1 / span 2;
 }

--- a/tests/integration/components/es-sidebar-test.js
+++ b/tests/integration/components/es-sidebar-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | es-sidebar', function (hooks) {
     `);
 
     assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '296px',
+      width: '300px',
     });
 
     await render(hbs`
@@ -47,10 +47,10 @@ module('Integration | Component | es-sidebar', function (hooks) {
     `);
 
     assert.dom('[data-test-content-left]').hasStyle({
-      width: '644px',
+      width: '604px',
     });
     assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '296px',
+      width: '300px',
       margin: '0px',
     });
 
@@ -62,11 +62,11 @@ module('Integration | Component | es-sidebar', function (hooks) {
     `);
 
     assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '296px',
+      width: '300px',
       margin: '0px',
     });
     assert.dom('[data-test-content-right]').hasStyle({
-      width: '644px',
+      width: '604px',
     });
   });
 });

--- a/tests/integration/components/es-sidebar-test.js
+++ b/tests/integration/components/es-sidebar-test.js
@@ -27,46 +27,4 @@ module('Integration | Component | es-sidebar', function (hooks) {
     await click('.es-sidebar-close');
     assert.dom('.es-sidebar').hasAttribute('aria-expanded', 'false');
   });
-
-  test('it has the correct styles when in a .sidebar-container', async function (assert) {
-    await render(hbs`
-      <div class="sidebar-container">
-        <EsSidebar>Test</EsSidebar>
-      </div>
-    `);
-
-    assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '300px',
-    });
-
-    await render(hbs`
-      <div class="sidebar-container">
-        <div data-test-content-left>Content left</div>
-        <EsSidebar>Test</EsSidebar>
-      </div>
-    `);
-
-    assert.dom('[data-test-content-left]').hasStyle({
-      width: '604px',
-    });
-    assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '300px',
-      margin: '0px',
-    });
-
-    await render(hbs`
-      <div class="sidebar-container">
-        <EsSidebar>Test</EsSidebar>
-        <div data-test-content-right>Content right</div>
-      </div>
-    `);
-
-    assert.dom('.sidebar-container .es-sidebar').hasStyle({
-      width: '300px',
-      margin: '0px',
-    });
-    assert.dom('[data-test-content-right]').hasStyle({
-      width: '604px',
-    });
-  });
 });


### PR DESCRIPTION
This moves some of the tweaks that we were doing in https://github.com/ember-learn/guidemaker-ember-template "upstream" into styleguide 👍 

Edit: This is a breaking change because any consumers of `<EsSidebar />` that didn't want to have a grey background will need to add `.bg-light` or reset the style themselves 👍 