### PR TITLE
#324  Fix the background and   text-decoration: underline

### DIFF
--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -167,9 +167,9 @@ main a:link,
 main a:visited {
   color: var(--color-link);
   text-decoration: none;
-  background: no-repeat left bottom
-    linear-gradient(var(--color-brand-40), var(--color-brand-40));
+  background: linear-gradient(var(--color-brand-40), var(--color-brand-40));
   background-size: 100% 0.1875rem;
+  background-repeat: no-repeat;
 }
 
 main a:focus,
@@ -177,6 +177,7 @@ main a:hover,
 main a:active,
 main .active {
   color: var(--color-link-hover);
+  text-decoration: underline;
 }
 
 *:focus {


### PR DESCRIPTION

### **Explanation of Changes:**

1->The `background` property in the `main a` styles was adjusted to ensure it is applied correctly without any issues.

2->The `text-decoration` property is set to `none` by default and will change to `underline` on hover or focus states, providing a clear visual indication of interactivity.

These changes should help resolve the bugs related to the background and text-decoration in your CSS