### PR TITLE
Do not show onClicked warning if @type is "submit"

### DIFF
--- a/addon/components/es-button.js
+++ b/addon/components/es-button.js
@@ -12,8 +12,10 @@ export default class EsButtonComponent extends Component {
 
 
     if(!this.args.onClicked) {
-      // eslint-disable-next-line no-console
-      console.warn(new Error('Button created with no onClicked'));
+      if (this.args.type !== 'submit') {
+        // eslint-disable-next-line no-console
+        console.warn(new Error('Button created with no onClicked'));
+      }
     } else {
       this._onClicked = this.args.onClicked;
     }


### PR DESCRIPTION
This is perfectly valid for submit buttons in a form:

```hbs
<EsButton @type="submit" @label="Search" />
```
This PR removes the console warning (and stack trace) when a submit button has no `onClicked` attribute.

You can see it in the wild by looking at the console output for the [component page for EsButton](https://ember-styleguide.netlify.app/components/button/).

Fixes #354
